### PR TITLE
Misc improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,8 @@ pip-delete-this-directory.txt
 
 # OSX
 *.DS_Store
+
+# Other
 workspace.code-workspace
+frontend/fastify/public/*
+*yarn.lock

--- a/backend/postgresql.sql
+++ b/backend/postgresql.sql
@@ -16,7 +16,8 @@ CREATE TABLE oig.producer (
     active BOOLEAN NOT NULL,
     logo_svg VARCHAR ( 100 ), /*Can be Null as sometimes people dont have a logo */
     country_code VARCHAR ( 100 ), /*Can be Null as sometimes people dont have a country specified */
-    top21 BOOLEAN NOT NULL
+    top21 BOOLEAN NOT NULL,
+    account_name VARCHAR ( 12 ) /* Used for login */
 );
 
 

--- a/frontend/fastify/pgquery.js
+++ b/frontend/fastify/pgquery.js
@@ -352,4 +352,4 @@ const addNewGuild = (request, reply) => {
     })
 }
 
-module.exports = { deleteItem, IsProducerActive, bizdevUpdate, communityUpdate, getBizdevs, getCommunity, getLatestResults, getLatestSnapshotResults, getPointSystem, updatePointSystem, getProducers, getProducts, getResults, getResultsbyOwner, getSnapshotResults, getSnapshotSettings, getUpdatesbyOwner, mothlyUpdate, productUpdate, setSnapshotResults, updateSnapshotDate, snapshotResultCommentUpdate, getPaginatedResultsByOwner };
+module.exports = { deleteItem, IsProducerActive, bizdevUpdate, communityUpdate, getBizdevs, getCommunity, getLatestResults, getLatestSnapshotResults, getPointSystem, updatePointSystem, getProducers, getProducts, getResults, getResultsbyOwner, getSnapshotResults, getSnapshotSettings, getUpdatesbyOwner, mothlyUpdate, productUpdate, setSnapshotResults, updateSnapshotDate, snapshotResultCommentUpdate, getPaginatedResultsByOwner, addNewGuild };

--- a/frontend/fastify/pgquery.js
+++ b/frontend/fastify/pgquery.js
@@ -16,7 +16,7 @@ client.connect()
 
 // Get all producers
 const getProducers = (request, reply) => {
-  client.query('SELECT * FROM oig.producer WHERE active ORDER BY owner_name ASC', (error, results) => {
+  client.query('SELECT * FROM oig.producer ORDER BY owner_name ASC', (error, results) => {
     if (error) {
       throw error
     }

--- a/frontend/fastify/pgquery.js
+++ b/frontend/fastify/pgquery.js
@@ -338,4 +338,18 @@ const deleteItem = (request, reply) => {
   })
 }
 
+const addNewGuild = (request, reply) => {
+  const { owner_name, url } = request.body
+  const active = true;
+  client.query(
+    `INSERT INTO "oig"."producer"("owner_name", "candidate", "url", "jsonurl", "chainsurl", "active") VALUES($1, ' ', $2, ' ', ' ', $3)`,
+    [owner_name, url, active],
+    (error, results) => {
+      if (error) {
+        throw error
+      }
+      reply.status(200).send(`Guild created! ${owner_name}`);
+    })
+}
+
 module.exports = { deleteItem, IsProducerActive, bizdevUpdate, communityUpdate, getBizdevs, getCommunity, getLatestResults, getLatestSnapshotResults, getPointSystem, updatePointSystem, getProducers, getProducts, getResults, getResultsbyOwner, getSnapshotResults, getSnapshotSettings, getUpdatesbyOwner, mothlyUpdate, productUpdate, setSnapshotResults, updateSnapshotDate, snapshotResultCommentUpdate, getPaginatedResultsByOwner };

--- a/frontend/fastify/server.js
+++ b/frontend/fastify/server.js
@@ -66,6 +66,8 @@ fastify.post('/api/updatePointSystem', db.updatePointSystem)
 fastify.post('/api/deleteItem', db.deleteItem)
 // Add new guild
 fastify.post('/api/addNewGuild', db.addNewGuild)
+// Truncated monthly results
+fastify.get('/api/truncatedPaginatedResults', db.getTruncatedPaginatedResults)
 
 // Starts the Fastify Server //
 const start = async () => {

--- a/frontend/fastify/server.js
+++ b/frontend/fastify/server.js
@@ -67,7 +67,7 @@ fastify.post('/api/deleteItem', db.deleteItem)
 // Add new guild
 fastify.post('/api/addNewGuild', db.addNewGuild)
 // Truncated monthly results
-fastify.get('/api/truncatedPaginatedResults', db.getTruncatedPaginatedResults)
+fastify.get('/api/truncatedPaginatedResults/:owner', db.getTruncatedPaginatedResults)
 
 // Starts the Fastify Server //
 const start = async () => {

--- a/frontend/fastify/server.js
+++ b/frontend/fastify/server.js
@@ -24,6 +24,7 @@ fastify.get('/snapshot', (req, reply) => reply.sendFile('index.html'))
 fastify.get('/admin', (req, reply) => reply.sendFile('index.html')) 
 fastify.get('/form', (req, reply) => reply.sendFile('index.html'))  
 fastify.get('/latestresults', (req, reply) => reply.sendFile('index.html'))
+fastify.get('/guilds/*', (req, reply) => reply.sendFile('index.html'))
 
 
 // PG Routes//

--- a/frontend/fastify/server.js
+++ b/frontend/fastify/server.js
@@ -64,6 +64,8 @@ fastify.post('/api/updateSnapshotDate', db.updateSnapshotDate)
 fastify.post('/api/updatePointSystem', db.updatePointSystem)
 // Delete items
 fastify.post('/api/deleteItem', db.deleteItem)
+// Add new guild
+fastify.post('/api/addNewGuild', db.addNewGuild)
 
 // Starts the Fastify Server //
 const start = async () => {

--- a/frontend/react-front/src/App.js
+++ b/frontend/react-front/src/App.js
@@ -161,6 +161,7 @@ const App = (props) => {
           latestresults={latestresults}
           producerLogos={producerLogos}
           producerDomainMap={producerDomainMap}
+          activeUser={props.ual.activeUser}
         />
       </>
     );

--- a/frontend/react-front/src/components/appbar.js
+++ b/frontend/react-front/src/components/appbar.js
@@ -112,7 +112,7 @@ export default function ButtonAppBar({ activeUser, loginModal, logOut, isAdmin }
           </Link>
           <Typography fontWeight="fontWeightBold" variant="h4" className={classes.title} color='inherit'>
             OIG Portal
-      </Typography>
+          </Typography>
           <nav className={classes.linkContainer}>
             <Link underline="none" variant="button" color="inherit" href="/" className={classes.link}>
               Home
@@ -124,13 +124,17 @@ export default function ButtonAppBar({ activeUser, loginModal, logOut, isAdmin }
               Scores
             </Link>
             {isAdmin ?
-            <Link underline="none" variant="button" color="inherit" href="/form" className={classes.link}>
-              Submit Update
+              <Link underline="none" variant="button" color="inherit" href="/form" className={classes.link}>
+                Submit Update
               </Link> : null}
             {isAdmin ?
               <Link variant="button" color="inherit" href="/admin" className={classes.link}>
                 Admin
-          </Link> : null}
+              </Link> : null}
+            {activeUser ?
+              <Link variant="button" color="inherit" href={`/guilds/${activeUser.accountName}`} className={classes.link}>
+                Profile
+              </Link> : null}
             <Link variant="button" color="inherit" href="#" onClick={activeUser ? logOut : loginModal} className={[classes.link, classes.waxButton]}>
               {activeUser ? "Log out " + activeUser.accountName : "Log In"}
             </Link>

--- a/frontend/react-front/src/components/producer-detail.js
+++ b/frontend/react-front/src/components/producer-detail.js
@@ -26,6 +26,9 @@ const useStyles = makeStyles((theme) => ({
     width: '100%',
     margin: '0 auto 50px',
   },
+  warning: {
+    textAlign: 'center !important'
+  },
   constrainedBox: {
     margin: '0 auto 50px',
     maxWidth: '550px'
@@ -148,11 +151,11 @@ const generateServicesProvided = (results) => {
   return jsx
 }
 
-const App = ({ producer, latestresults, producerLogos, producerDomainMap }) => {
+const App = ({ producer, latestresults, producerLogos, producerDomainMap, activeUser }) => {
   const classes = useStyles();
   const [results, setResults] = useState([]);
 
-  const preload = 42; // Number of results to preload (21 for 1 page, 42 for 2)
+  const preload = 60; // Number of results to preload (21 for 1 page, 42 for 2)
 
   useEffect(() => {
     if (producer) {
@@ -176,30 +179,31 @@ const App = ({ producer, latestresults, producerLogos, producerDomainMap }) => {
   return (
     <div className={classes.root}>
       {producer ? <h1>{producer.candidate} <small>{producer.owner_name}</small></h1> : null}
+      {results.length === 0 ? <h2 className={classes.warning}>No data recorded for this guild yet.</h2> : !producer.active ? <h2 className={classes.warning}>This guild is retired.</h2> : activeUser && activeUser.accountName === producer.account_name ? <h2 className={classes.warning}>This is your guild.</h2> : null }
       <div className={classes.constrainedBox}>
-        <Paper className={[classes.paper, classes.logoAndFlag]} variant="outlined">
-          {producer && producerLogos ? <img alt={producer.candidate + " logo"} className={classes.guildLogo} src={getCachedImage(producer.logo_svg, producerLogos, producerDomainMap)} /> : null}
+        {producer && (producer.logo_svg || producer.country_code) ? <Paper className={[classes.paper, classes.logoAndFlag]} variant="outlined">
+          {producerLogos ? <img alt={producer.candidate + " logo"} className={classes.guildLogo} src={getCachedImage(producer.logo_svg, producerLogos, producerDomainMap)} /> : null}
           <br />
-          {producer && flagMap[producer.country_code] ? <span className={classes.flagIcon}>
+          {flagMap[producer.country_code] ? <span className={classes.flagIcon}>
             {flagMap[producer.country_code]}
           </span> : null}
-        </Paper>
-        <Paper className={[classes.paper, classes.servicesProvided]} variant="outlined">
+        </Paper> : null }
+        {results.length >=1 ? <Paper className={[classes.paper, classes.servicesProvided]} variant="outlined">
           <h2>Services Provided</h2>
           <ul>
             {generateServicesProvided(results)}
           </ul>
-        </Paper>
+        </Paper> : null}
       </div>
-      <Paper className={[classes.paper, classes.cpuStatsHolder]} variant="outlined">
+      {results.length >=1 ? <Paper className={[classes.paper, classes.cpuStatsHolder]} variant="outlined">
         <h2>CPU stats</h2>
         <CpuStatsGraph results={results.slice(0, 7)} latestresults={latestresults} />
-      </Paper>
-      <Paper className={[classes.paper, classes.smallCpuStats]} variant="outlined">
+      </Paper> : null}
+      {results.length >=1 ? <Paper className={[classes.paper, classes.smallCpuStats]} variant="outlined">
         <h2>CPU stats</h2>
         <p>{cpuSummary({ results: results.slice(0, 7), latestresults})}</p>
-      </Paper>
-      <h2>Latest Results</h2>
+      </Paper> : null }
+      {results.length >=1 ? <h2>Latest Results</h2> : null }
       {results.length >= 1 ? <TechresultTables
         passedResults={results}
         hideOwnerName={true}

--- a/frontend/react-front/src/components/producer-detail.js
+++ b/frontend/react-front/src/components/producer-detail.js
@@ -156,7 +156,7 @@ const App = ({ producer, latestresults, producerLogos, producerDomainMap }) => {
 
   useEffect(() => {
     if (producer) {
-      axios.get(api_base + `/api/paginatedresults/${producer.owner_name}?index=0&limit=${preload - 1}`).then((response) => {
+      axios.get(api_base + `/api/truncatedPaginatedResults/${producer.owner_name}?index=0&limit=${preload - 1}`).then((response) => {
         setResults(response.data)
       })
     }
@@ -167,7 +167,7 @@ const App = ({ producer, latestresults, producerLogos, producerDomainMap }) => {
     if (!index || !limit) {
       return results
     }
-    const paginatedResults = await axios.get(api_base + `/api/paginatedresults/${producer.owner_name}?index=${index}&limit=${limit}`);
+    const paginatedResults = await axios.get(api_base + `/api/truncatedPaginatedResults/${producer.owner_name}?index=${index}&limit=${limit}`);
     const newResults = [...results, ...paginatedResults.data];
     setResults(newResults);
     return newResults;

--- a/frontend/react-front/src/components/producer-results.js
+++ b/frontend/react-front/src/components/producer-results.js
@@ -95,7 +95,7 @@ const App = ({ results, producers, products, bizdevs, community, producerLogos, 
   // Counts all scores together
   function totalscore(tech, product, bizdev, community) {
     // Set passing score
-    let pass = 150
+    let pass = 120
     let sum = parseInt(tech) + product + bizdev + community
     if (sum >= pass) {
       return (

--- a/frontend/react-front/src/components/producer-results.js
+++ b/frontend/react-front/src/components/producer-results.js
@@ -20,6 +20,12 @@ import getCachedImage from './getCachedImage'
 const useStyles = makeStyles((theme) => ({
   root: {
   },
+  retired: {
+    opacity: 0.7,
+    '& *': {
+      filter: 'grayscale(1)'
+    }
+  },
   media: {
     height: 0,
     paddingTop: '56.25%', // 16:9
@@ -171,22 +177,67 @@ const App = ({ results, producers, products, bizdevs, community, producerLogos, 
     );
   }
 
+  const isActive = (owner_name) => {
+    const owner = producers.find(producer => producer.owner_name === owner_name)
+    return owner ? (owner.active !== false && owner.active !== null) : true;
+  }
 
   return (
     <Grid container spacing={4}>
-      {results.map((result) => (
+      {results.map((result) => {
+        return isActive(result.owner_name) === true ? (
+          /* ACTIVE */
+          <Grid item key={result.owner_name} xs={12} sm={6} md={3}>
+            <Card className={classes.root} variant="outlined">
+              <Link className={classes.link} to={`/guilds/${result.owner_name}`}>
+                <CardHeader
+                  avatar={
+                    <Avatar alt={result.owner_name} src={logo(result.owner_name)} className={classes.large} />
+                  }
+                  /*action={
+                    <IconButton aria-label="settings">
+                      <MoreVertIcon />
+                    </IconButton>
+                  }*/
+                  title={result.owner_name}
+                  subheader={datec(result.date_check)}
+                  className={classes.cardHeader}
+                />
+              </Link>
+              <CardContent className={classes.summary}>
+                <Typography variant="body2" color="textSecondary" component="p">
+                  <b>Tech: </b>{parseInt(result.score)}
+                </Typography>
+                <Typography variant="body2" color="textSecondary" component="p">
+                  <b>Products: </b>{statescore(result.owner_name, products)}
+                </Typography>
+                <Typography variant="body2" color="textSecondary" component="p">
+                  <b>Bizdev: </b>{statescore(result.owner_name, bizdevs)}
+                </Typography>
+                <Typography variant="body2" color="textSecondary" component="p">
+                  <b>Community: </b>{statescore(result.owner_name, community)}
+                </Typography>
+              </CardContent>
+              <CardActions disableSpacing>
+                {top21(result.owner_name)}
+                <IconButton aria-label="share">
+                  {textResult(result.tls_check)}
+                </IconButton>
+                <IconButton className={classes.left} >
+                  {totalscore(result.score, statescore(result.owner_name, products), statescore(result.owner_name, bizdevs), statescore(result.owner_name, community))}
+                </IconButton>
+              </CardActions>
+            </Card>
+          </Grid>
+        ) : (
+        /* INACTIVE */
         <Grid item key={result.owner_name} xs={12} sm={6} md={3}>
-          <Card className={classes.root} variant="outlined">
+          <Card className={[classes.root, classes.retired]} variant="outlined">
             <Link className={classes.link} to={`/guilds/${result.owner_name}`}>
               <CardHeader
                 avatar={
                   <Avatar alt={result.owner_name} src={logo(result.owner_name)} className={classes.large} />
                 }
-                /*action={
-                  <IconButton aria-label="settings">
-                    <MoreVertIcon />
-                  </IconButton>
-                }*/
                 title={result.owner_name}
                 subheader={datec(result.date_check)}
                 className={classes.cardHeader}
@@ -216,9 +267,9 @@ const App = ({ results, producers, products, bizdevs, community, producerLogos, 
               </IconButton>
             </CardActions>
           </Card>
-        </Grid>
-      ))}
-    </Grid>
+        </Grid>)
+      }
+      )}</Grid>
   );
 }
 


### PR DESCRIPTION
## Biggest visual changes:

#### Better context on guild page:
![Screen Shot 2021-07-10 at 00 50 43](https://user-images.githubusercontent.com/9779954/125150878-6af7f880-e119-11eb-8b85-d24be895aa07.png)
![Screen Shot 2021-07-10 at 00 46 29](https://user-images.githubusercontent.com/9779954/125150879-6c292580-e119-11eb-9200-0c487e631b2c.png)
![Screen Shot 2021-07-10 at 00 44 23](https://user-images.githubusercontent.com/9779954/125150881-6cc1bc00-e119-11eb-8dfb-577a8a286eaa.png)

#### Greyed-out retired guilds:
![Screen Shot 2021-07-10 at 00 46 54](https://user-images.githubusercontent.com/9779954/125150883-6df2e900-e119-11eb-9fb6-044d3fbad828.png)

## Other changes
- Fix the display of inactive or blank guilds
- Change producers query to show inactive
- Deactivate guild query (guild name) (already done!)
- Add new guild query (only owner name and URL)
- Add database column called account name
- Add "profile" to navbar when logged in
- Fix the issue where /guilds/XYZ didn't show up when directly linked on the deployed site
- Set min score to 120 (frontnend only)

## What I didn't complete:

- **2 results per day** for the last month (for individual guild tech results.) I spent a lot of time trying to figure it out and probably the closest I got was a query that could return results like this:

```
date		min		max
2021-01-08	119.7365	119.7365
2021-01-05	82.8945	101.3155
2021-01-03	82.8945	82.8945
2020-12-27	101.3155	147.368
```

But I couldn't extend that further, not even in a heavily nested query, in order to get just 2 results, the min and max for every day. I either got one or more than 2.

My approach going forward from here would probably be to partially process the data with JavaScript (via fastify, so at least it's a little more fast than the frontend)... but that's definitely far from ideal - considering that there could be over 2.5k rows for a monthlong period (assuming checks every 15 mins, 96 a day). I'll try ask some SQL-experienced friends if they've approached similar problems before.

- **Retired guilds button** at the bottom, with retired guilds popping down below it.

I was actually keen to know whether you wanted this as an option to toggle up at the top instead? I think with the visual difference I've added to retired guilds, they are pretty easy to pick out. However, if you're sure you want them at the bottom, I can make that happen.

- **Form to add new guilds via admin page**. The fastify function is done though so it won't be too tricky.

- **Scaffolding to allow admins to tweak min scores**