### PR TITLE
Fastify, global, and guild improvements

### DIFF
--- a/files/db-start.sh
+++ b/files/db-start.sh
@@ -91,6 +91,8 @@ echo "creating initdb.sql file"
           date_check TIMESTAMPTZ NOT NULL,
           score DECIMAL NOT NULL,
           snapshot_date TIMESTAMPTZ,
+          atomic_api_error VARCHAR ( 1000 ),
+          atomic_api BOOLEAN NOT NULL,
           comments VARCHAR ( 1000 )
       );
       /* Unique index to cover two culumns*/

--- a/frontend/fastify/pgquery.js
+++ b/frontend/fastify/pgquery.js
@@ -234,7 +234,21 @@ const IsProducerActive = (request, reply) => {
     if (error) {
       throw error
     }
-    reply.status(200).send(`Producer modified: ${owner}`);
+    reply.status(200).send(`${owner} is active: ${active ? "true" : "false"}`);
+  })
+}
+
+
+// Set producer account_name
+const setAccountName = (request, reply) => {
+  const owner = request.params.owner
+  const { account_name } = request.body
+
+  client.query('UPDATE oig.producer SET account_name = $1 WHERE owner_name = $2', [account_name, owner], (error, results) => {
+    if (error) {
+      throw error
+    }
+    reply.status(200).send(`Account name for ${owner} set to ${account_name}`);
   })
 }
 
@@ -388,4 +402,4 @@ const addNewGuild = (request, reply) => {
     })
 }
 
-module.exports = { deleteItem, IsProducerActive, bizdevUpdate, communityUpdate, getBizdevs, getCommunity, getLatestResults, getLatestSnapshotResults, getPointSystem, updatePointSystem, getProducers, getProducts, getResults, getResultsbyOwner, getSnapshotResults, getSnapshotSettings, getUpdatesbyOwner, mothlyUpdate, productUpdate, setSnapshotResults, updateSnapshotDate, snapshotResultCommentUpdate, getPaginatedResultsByOwner, addNewGuild, getTruncatedPaginatedResults };
+module.exports = { deleteItem, IsProducerActive, bizdevUpdate, communityUpdate, getBizdevs, getCommunity, getLatestResults, getLatestSnapshotResults, getPointSystem, updatePointSystem, getProducers, getProducts, getResults, getResultsbyOwner, getSnapshotResults, getSnapshotSettings, getUpdatesbyOwner, mothlyUpdate, productUpdate, setSnapshotResults, updateSnapshotDate, snapshotResultCommentUpdate, getPaginatedResultsByOwner, addNewGuild, getTruncatedPaginatedResults, setAccountName };

--- a/frontend/fastify/server.js
+++ b/frontend/fastify/server.js
@@ -47,6 +47,8 @@ fastify.get('/api/pointsystem', db.getPointSystem)
 fastify.post('/api/snapshot', db.setSnapshotResults)
 // Activate or deactivate producer
 fastify.put('/api/activeproducer/:owner', db.IsProducerActive)
+// Set account name of producer
+fastify.put('/api/setAccountName/:owner', db.setAccountName)
 // Guild add monthly updates
 fastify.post('/api/monthlyUpdate', db.mothlyUpdate)
 // Guild product updates/insert

--- a/frontend/react-front/src/App.js
+++ b/frontend/react-front/src/App.js
@@ -56,6 +56,7 @@ const App = (props) => {
   const classes = useStyles();
   // const [rawResults, setRawResults] = useState([])
   // const [results, setResults] = useState([])
+  const [rawProducers, setRawProducers] = useState([])
   const [producers, setProducers] = useState([])
   // const [rawProducts, setRawProducts] = useState([])
   const [products, setProducts] = useState([])
@@ -78,7 +79,8 @@ const App = (props) => {
       setResults(response.data)
     });*/
     axios.get(api_base + '/api/producers').then((response) => {
-      setProducers(response.data)
+      setRawProducers(response.data)
+      setProducers(response.data.filter((producer) => producer.active === true))
     });
     axios.get(api_base + '/api/products').then((response) => {
       // setRawProducts(response.data)
@@ -157,7 +159,7 @@ const App = (props) => {
     return (
       <>
         <ProducerDetails
-          producer={producers.filter((result) => result.owner_name === params.ownername)[0]}
+          producer={rawProducers.filter((result) => result.owner_name === params.ownername)[0]}
           latestresults={latestresults}
           producerLogos={producerLogos}
           producerDomainMap={producerDomainMap}
@@ -184,6 +186,7 @@ const App = (props) => {
                   <Router>
                     <Route path="/latestresults" component={() => <MonthlyResults
                       results={latestresults}
+                      activeGuilds={rawProducers.filter(producer => producer.active === true).map(producer => producer.owner_name)}
                     />} exact />
                     <Route exact path="/snapshot" component={() => <SnapshotResults
                       /*results={latestresults}*/
@@ -196,10 +199,11 @@ const App = (props) => {
                       isAdmin={adminOverride || (props.ual.activeUser && admins.indexOf(props.ual.activeUser.accountName) !== -1)}
                       producerLogos={producerLogos}
                       producerDomainMap={producerDomainMap}
+                      activeGuilds={rawProducers.filter(producer => producer.active === true).map(producer => producer.owner_name)}
                     />} />
                     <Route exact path="/" component={() =>
                       <ProducerCards results={latestresults}
-                        producers={producers}
+                        producers={rawProducers}
                         products={products}
                         bizdevs={bizdevs}
                         community={community}
@@ -208,7 +212,7 @@ const App = (props) => {
                       />} />
                     <Route exact path='/guilds/:ownername' component={BPwithownername} />
                     <Route exact path='/form' component={() => <Testform producers={producers} isAdmin={adminOverride || (props.ual.activeUser && admins.indexOf(props.ual.activeUser.accountName) !== -1)} />} />
-                    <Route exact path='/admin' component={() => <AdminPanel snapshotSettings={snapshotSettings} pointSystem={rawPointSystem} isAdmin={adminOverride || (props.ual.activeUser && admins.indexOf(props.ual.activeUser.accountName) !== -1)} />} />
+                    <Route exact path='/admin' component={() => <AdminPanel snapshotSettings={snapshotSettings} producers={rawProducers} pointSystem={rawPointSystem} isAdmin={adminOverride || (props.ual.activeUser && admins.indexOf(props.ual.activeUser.accountName) !== -1)} />} />
                   </Router>
                 </Paper>
               </Grid>

--- a/frontend/react-front/src/components/admin.js
+++ b/frontend/react-front/src/components/admin.js
@@ -18,7 +18,7 @@ const useStyles = makeStyles((theme) => ({
     }
 }))
 
-const AdminPanel = ({ snapshotSettings, pointSystem, isAdmin }) => {
+const AdminPanel = ({ snapshotSettings, producers, pointSystem, isAdmin }) => {
     const classes = useStyles();
     const [snapshotDate, updateSnapshotDate] = useState(null);
 

--- a/frontend/react-front/src/components/integrated-snapshot-scores.js
+++ b/frontend/react-front/src/components/integrated-snapshot-scores.js
@@ -12,18 +12,18 @@ function getGuildLogoURL(guild, producers, producerLogos, producerDomainMap) {
   return getCachedImage(logosvg_url, producerLogos, producerDomainMap)
 }
 
-const App = ({ results, producers, products, bizdevs, community, isAdmin, pointSystem, producerLogos, producerDomainMap }) => {
+const App = ({ results, producers, products, bizdevs, community, isAdmin, pointSystem, producerLogos, producerDomainMap, activeGuilds }) => {
   function format(array) {
     // Any manipulations of initially loaded data can be done here
     if (array.length >= 1) {
       // Place comments second to front for product & bizdev, front for community & tech
-      return array.map((item) => {
+      return array.map(item => {
         const itemWithGuildLogo = {
           guild: getGuildLogoURL(item.owner_name, producers, producerLogos, producerDomainMap),
           ...item
         }
         return reArrangeTableHeaders(itemWithGuildLogo)
-      })
+      }).filter(result => activeGuilds.indexOf(result.owner_name) !== -1)
     }
     return array
   }

--- a/frontend/react-front/src/components/producer-detail.js
+++ b/frontend/react-front/src/components/producer-detail.js
@@ -133,6 +133,7 @@ const generateServicesProvided = (results) => {
   const services = [
     ["History V1", latest.hyperion_v2, null],
     ["Hyperion V2", latest.hyperion_v2, null],
+    ["Atomic API", latest.atomic_api, null],
     ["API", latest.api_node, null],
     ["Missed Blocks (24 hours)", null, null],
     ["Security (TLS >= v1.2)", latest.tls_check && latest.tls_check !== "false" && latest.tls_check.indexOf('1.2') !== -1, 'fa fa-shield-alt']

--- a/frontend/react-front/src/components/results.js
+++ b/frontend/react-front/src/components/results.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import TechresultTables from './tech-tablelist-results'
 
-const App = ({ results }) => {
+const App = ({ results, activeGuilds }) => {
   return (
     <div>
       <h1>Latest Results</h1>
       <TechresultTables
             passedResults={ results }
+            activeGuilds={ activeGuilds }
             description="WAX Mainnet"
        />
     </div>

--- a/frontend/react-front/src/components/snapshot-results.js
+++ b/frontend/react-front/src/components/snapshot-results.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
-const App = ({ /*results, */ producers, products, bizdevs, community, snapresults, pointSystem, isAdmin, producerLogos, producerDomainMap }) => {
+const App = ({ /*results, */ producers, products, bizdevs, community, snapresults, pointSystem, isAdmin, producerLogos, producerDomainMap, activeGuilds }) => {
   const classes = useStyles();
   
   const [viewType, setViewType] = useState('integrated')
@@ -53,6 +53,7 @@ const App = ({ /*results, */ producers, products, bizdevs, community, snapresult
         isAdmin={isAdmin}
         producerLogos={producerLogos}
         producerDomainMap={producerDomainMap}
+        activeGuilds={activeGuilds}
       />
     }
     return null

--- a/frontend/react-front/src/components/table-datagrid.js
+++ b/frontend/react-front/src/components/table-datagrid.js
@@ -27,7 +27,7 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
-export default function Table({ tableData, tableTitle, defaultGuild, isAdmin, pointSystem }) {
+export default function Table({ tableData, tableTitle, defaultGuild, isAdmin, pointSystem, activeGuilds }) {
   const classes = useStyles();
   const [tableState, setTableState] = useState(tableData);
 

--- a/frontend/react-front/src/components/tech-tablelist-results.js
+++ b/frontend/react-front/src/components/tech-tablelist-results.js
@@ -116,7 +116,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function ResultTables({ passedResults, hideOwnerName, loadMoreResults }) {
+export default function ResultTables({ passedResults, hideOwnerName, loadMoreResults, activeGuilds }) {
   // Basic paginaton frontend setup - 21 results
   const initialIndex = 21;
   const [results, setResults] = useState(passedResults);
@@ -136,7 +136,7 @@ export default function ResultTables({ passedResults, hideOwnerName, loadMoreRes
       let rows = results;
       const draftEndSlice = resultIndex + initialIndex - 1; // 21-1 initially. Then 42-1, and 63-1
       let endSlice = draftEndSlice >= max ? max : draftEndSlice; // set end slice to (20+21) - row 42, (41+21) - row 63, or (62+21) - row 84 - if it exceeds the loaded max (41) - row 42 use that instead
-      if (draftEndSlice >= (max+1) && !fetchForwardLimit) { // X >= 42 (row 43) initially
+      if (draftEndSlice >= (max + 1) && !fetchForwardLimit) { // X >= 42 (row 43) initially
         const index = endSlice + 1; // 41+1 (row 43)
         const limit = draftEndSlice; // 63-1 on third press (row 63)
         rows = await loadMoreResults(index, limit); // index 42-62 (row 43-64) should be now appended
@@ -213,6 +213,7 @@ export default function ResultTables({ passedResults, hideOwnerName, loadMoreRes
               <StyledTableCell><span>http2_check</span></StyledTableCell>
               <StyledTableCell><span>history_v1</span></StyledTableCell>
               <StyledTableCell><span>hyperion_v2</span></StyledTableCell>
+              <StyledTableCell><span>atomic_api</span></StyledTableCell>
               <StyledTableCell><span>cors_check</span></StyledTableCell>
               <StyledTableCell><span>oracle_feed</span></StyledTableCell>
               <StyledTableCell><span>snapshots</span></StyledTableCell>
@@ -222,8 +223,8 @@ export default function ResultTables({ passedResults, hideOwnerName, loadMoreRes
             </TableRow>
           </TableHead>
           <TableBody>
-            {resultSlice.map((result) => (
-              <StyledTableRow key={result.key}>
+            {resultSlice.map((result) => {
+              return !hideOwnerName && activeGuilds && activeGuilds.indexOf(result.owner_name) === -1 ? null : <StyledTableRow key={result.key}>
                 {hideOwnerName === true ? null : <StyledTableCell className={classes.ownerName}><a className={classes.waxButton} href={`/guilds/${result.owner_name}`}>{result.owner_name}</a></StyledTableCell>}
                 <StyledTableCell>{iconResult(result.chains_json)}</StyledTableCell>
                 <StyledTableCell>{iconResult(result.wax_json)}</StyledTableCell>
@@ -239,7 +240,7 @@ export default function ResultTables({ passedResults, hideOwnerName, loadMoreRes
                 <HtmlTooltip title={result.https_check_error} aria-label="https_check_error" placement="top">
                   <StyledTableCell>{iconResult(result.https_check)}</StyledTableCell>
                 </HtmlTooltip>
-                <HtmlTooltip title={result.https_check_error} aria-label="tls_check_error" placement="top">
+                <HtmlTooltip title={result.tls_check_error} aria-label="tls_check_error" placement="top">
                   <StyledTableCell>{textResult(result.tls_check)}</StyledTableCell>
                 </HtmlTooltip>
                 <HtmlTooltip title={result.http2_check_error} aria-label="http2_check_error" placement="top">
@@ -248,8 +249,11 @@ export default function ResultTables({ passedResults, hideOwnerName, loadMoreRes
                 <HtmlTooltip title={result.full_history_error} aria-label="full_history_error" placement="top">
                   <StyledTableCell>{iconResult(result.full_history)}</StyledTableCell>
                 </HtmlTooltip>
-                <HtmlTooltip title={result.full_history_error} aria-label="hyperion_v2_error" placement="top">
+                <HtmlTooltip title={result.hyperion_v2_error} aria-label="hyperion_v2_error" placement="top">
                   <StyledTableCell>{iconResult(result.hyperion_v2)}</StyledTableCell>
+                </HtmlTooltip>
+                <HtmlTooltip title={result.atomic_api_error} aria-label="atomic_api_error" placement="top">
+                  <StyledTableCell>{iconResult(result.atomic_api)}</StyledTableCell>
                 </HtmlTooltip>
                 <HtmlTooltip title={result.cors_check_error} aria-label="cors_check_error" placement="top">
                   <StyledTableCell>{iconResult(result.cors_check)}</StyledTableCell>
@@ -262,7 +266,7 @@ export default function ResultTables({ passedResults, hideOwnerName, loadMoreRes
                 <StyledTableCell>{Math.round(result.score) /* !pointSystem ? result.score : getTechScore(result, pointSystem) */}</StyledTableCell>
                 <StyledTableCell>{datec(result.date_check)}</StyledTableCell>
               </StyledTableRow>
-            ))}
+            })}
           </TableBody>
         </Table>
       </TableContainer>


### PR DESCRIPTION
-Query to edit or add account_name
-Include atomic_api across the app
-Update db-start to include atomic_api
-Exclude retired guilds from showing up in places they shouldn't

Took me a little longer than expected to properly filter the retired/unretired guilds.

Still in progress is the admin table allowing the editing of guild details - specifically, setting account_name and toggling on/off status. I'm using table-datagrid, with a clone of the current pointsystem table, same size, look and shape. I'll aim to finish this tomorrow, or max, on Thursday.

## Atomic API
![Screen Shot 2021-07-14 at 00 44 34](https://user-images.githubusercontent.com/9779954/125564248-7750c709-8011-45b3-bb8b-e0f8e2b3317c.png)
![Screen Shot 2021-07-14 at 00 48 41](https://user-images.githubusercontent.com/9779954/125564264-8a94995f-3022-405a-9c89-e185e6579316.png)

## Retired guilds now hidden (look for "amsterdamwax" which I used as a test)
![Screen Shot 2021-07-14 at 01 58 35](https://user-images.githubusercontent.com/9779954/125564331-ec970996-39d6-4c68-a43b-d861ef7be601.png)
![Screen Shot 2021-07-14 at 01 59 21](https://user-images.githubusercontent.com/9779954/125564334-45b431a9-8e23-4ac7-87c1-1693ad4c7371.png)
