### PR TITLE
Add minimum tech score to DB and admin panel

### DIFF
--- a/backend/db_changes.sql
+++ b/backend/db_changes.sql
@@ -14,3 +14,11 @@ add atomic_api_error VARCHAR ( 1000 );
 
 INSERT INTO oig.pointsystem(points_type,points,multiplier,min_requirements)
 VALUES ('atomic_api','2','11',false);
+
+-- Do this while logged into oiguser / the user fastify will log in as
+
+CREATE TABLE oig.adminsettings (
+    minimum_tech_score SMALLINT NOT NULL 
+);
+
+INSERT INTO oig.adminsettings(minimum_tech_score) VALUES(120);

--- a/backend/postgresql.sql
+++ b/backend/postgresql.sql
@@ -131,6 +131,10 @@ CREATE TABLE oig.snapshotsettings (
     snapshot_date TIMESTAMPTZ 
 );
 
+CREATE TABLE oig.adminsettings (
+    minimum_tech_score SMALLINT NOT NULL 
+);
+
 CREATE TABLE oig.updates (
 	owner_name VARCHAR ( 12 ),
 	tech_ops VARCHAR ( 10000 ),

--- a/frontend/fastify/pgquery.js
+++ b/frontend/fastify/pgquery.js
@@ -130,6 +130,36 @@ const updatePointSystem = (request, reply) => {
     })
 }
 
+const getAdminSettings = (request, reply) => {
+  console.log(pguser, pgport, pgpassword, pgdb, pghost)
+  client.query('SELECT * FROM oig.adminsettings', (error, results) => {
+    if (error) {
+      throw error
+    }
+    reply.status(200).send(results.rows);
+  })
+}
+
+// Update point system
+const updateAdminSettings = (request, reply) => {
+  const { minimum_tech_score } = request.body
+
+  const toUpdate = (minimum_tech_score ? "minimum_tech_score=" + minimum_tech_score : "");
+
+  if (toUpdate === "") {
+    reply.status(400).send(`No updates sent`);
+  } else {
+    client.query(
+      `UPDATE oig.adminsettings SET ${toUpdate}`,
+      (error, results) => {
+        if (error) {
+          throw error
+        }
+        reply.status(200).send(`Minimum tech score updated`);
+      })
+  }
+}
+
 //Set a snapshot for latest results where results is less than 1 minutes based on date_check timestamp of latest results.
 //UPDATE oig.results SET snaphot_date = $2 WHERE owner_name = $1 AND date_check > NOW() - INTERVAL '15 minutes'
 //update oig.results set snapshot_date = '2020-09-11 17:18:04.825519' where owner_name = 'eos42freedom' and date_check > timestamp '2020-10-23 17:31:22' - INTERVAL '1 minute';
@@ -415,4 +445,4 @@ const addNewGuild = (request, reply) => {
     })
 }
 
-module.exports = { deleteItem, IsProducerActive, bizdevUpdate, communityUpdate, getBizdevs, getCommunity, getLatestResults, getLatestSnapshotResults, getPointSystem, updatePointSystem, getProducers, getProducts, getResults, getResultsbyOwner, getSnapshotResults, getSnapshotSettings, getUpdatesbyOwner, mothlyUpdate, productUpdate, setSnapshotResults, updateSnapshotDate, snapshotResultCommentUpdate, getPaginatedResultsByOwner, addNewGuild, getTruncatedPaginatedResults, setAccountName, updateProducer };
+module.exports = { deleteItem, IsProducerActive, bizdevUpdate, communityUpdate, getBizdevs, getCommunity, getLatestResults, getLatestSnapshotResults, getPointSystem, updatePointSystem, getProducers, getProducts, getResults, getResultsbyOwner, getSnapshotResults, getSnapshotSettings, getUpdatesbyOwner, mothlyUpdate, productUpdate, setSnapshotResults, updateSnapshotDate, snapshotResultCommentUpdate, getPaginatedResultsByOwner, addNewGuild, getTruncatedPaginatedResults, setAccountName, updateProducer, getAdminSettings, updateAdminSettings };

--- a/frontend/fastify/server.js
+++ b/frontend/fastify/server.js
@@ -72,6 +72,9 @@ fastify.post('/api/deleteItem', db.deleteItem)
 fastify.post('/api/addNewGuild', db.addNewGuild)
 // Truncated monthly results
 fastify.get('/api/truncatedPaginatedResults/:owner', db.getTruncatedPaginatedResults)
+// Admin settings - just minimum tech score for now
+fastify.get('/api/getAdminSettings', db.getAdminSettings)
+fastify.post('/api/updateAdminSettings', db.updateAdminSettings)
 
 // Starts the Fastify Server //
 const start = async () => {

--- a/frontend/react-front/src/App.js
+++ b/frontend/react-front/src/App.js
@@ -71,6 +71,7 @@ const App = (props) => {
   const [snapshotSettings, setSnapshotSettings] = useState([])
   const [rawPointSystem, setRawPointSystem] = useState([])
   const [pointSystem, setPointSystem] = useState([])
+  const [minimumTechScore, setMinimumTechScore] = useState([]);
 
   useEffect(() => {
     // Load data and set hooks. A future implementation could use axios.all
@@ -115,6 +116,11 @@ const App = (props) => {
       });
       setPointSystem(formattedPointSystem)
     })
+    axios.get(api_base + '/api/getAdminSettings').then((response) => {
+      const data = response.data;
+      const minScore = data && data[0] && data[0].minimum_tech_score ? data[0].minimum_tech_score : 999;
+      setMinimumTechScore(minScore)
+    });
   }, []);
 
   /* Calculate scores if formatted point system exists, and raw data (to be scored) exists
@@ -209,10 +215,11 @@ const App = (props) => {
                         community={community}
                         producerLogos={producerLogos}
                         producerDomainMap={producerDomainMap}
+                        minimumTechScore={minimumTechScore}
                       />} />
                     <Route exact path='/guilds/:ownername' component={BPwithownername} />
                     <Route exact path='/form' component={() => <Testform producers={producers} isAdmin={adminOverride || (props.ual.activeUser && admins.indexOf(props.ual.activeUser.accountName) !== -1)} />} />
-                    <Route exact path='/admin' component={() => <AdminPanel snapshotSettings={snapshotSettings} producers={rawProducers} pointSystem={rawPointSystem} isAdmin={adminOverride || (props.ual.activeUser && admins.indexOf(props.ual.activeUser.accountName) !== -1)} />} />
+                    <Route exact path='/admin' component={() => <AdminPanel snapshotSettings={snapshotSettings} producers={rawProducers} pointSystem={rawPointSystem} isAdmin={adminOverride || (props.ual.activeUser && admins.indexOf(props.ual.activeUser.accountName) !== -1)} minimumTechScore={minimumTechScore} />} />
                   </Router>
                 </Paper>
               </Grid>

--- a/frontend/react-front/src/components/admin.js
+++ b/frontend/react-front/src/components/admin.js
@@ -3,7 +3,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { MuiPickersUtilsProvider, KeyboardDateTimePicker } from '@material-ui/pickers';
 import { api_base } from "../config";
 import axios from "axios";
-import { Button } from '@material-ui/core';
+import { Button, TextField } from '@material-ui/core';
 import TableDataGrid from './table-datagrid'
 import moment from 'moment-timezone'
 import MomentUtils from '@date-io/moment'
@@ -17,14 +17,19 @@ const useStyles = makeStyles((theme) => ({
     datePicker: {
         minWidth: "290px"
     },
+    techScore: {
+        maxWidth: "290px"
+    },
     hidden: {
         display: 'none'
     }
 }))
 
-const AdminPanel = ({ snapshotSettings, producers, pointSystem, isAdmin }) => {
+const AdminPanel = ({ snapshotSettings, producers, pointSystem, isAdmin, minimumTechScore }) => {
     const classes = useStyles();
     const [snapshotDate, updateSnapshotDate] = useState(null);
+    const [passedScore, updatePassedScore] = useState(120)
+    const [minTechScore, updateMinTechScore] = useState(minimumTechScore);
     const [currentTable, setCurrentTable] = useState('pointSystem')
 
     const handleDateChange = (dateChange) => {
@@ -36,6 +41,21 @@ const AdminPanel = ({ snapshotSettings, producers, pointSystem, isAdmin }) => {
             );
         });
         updateSnapshotDate(dateChange)
+    }
+
+    const handleTechScoreChange = (event) => {
+        updateMinTechScore(event.target.value)
+    }
+
+    const handleSaveTechScoreChange = () => {
+        axios.post(api_base + "/api/updateAdminSettings", {
+            minimum_tech_score: minTechScore
+        }).then(() => {
+            console.log(
+                `Minimum tech score updated to ${minTechScore}! Reload to confirm.`
+            );
+        });
+        updatePassedScore(minTechScore)
     }
 
     if (!snapshotDate && !!snapshotSettings[0]) {
@@ -64,6 +84,18 @@ const AdminPanel = ({ snapshotSettings, producers, pointSystem, isAdmin }) => {
 
     return isAdmin ? <div className={classes.root}>
         <h1>Admin Panel</h1>
+        {minTechScore ? <TextField value={minTechScore} className={classes.techScore} fullWidth="true" onChange={handleTechScoreChange} label="Minimum Tech Score"></TextField> : null }
+        <br></br><br></br>
+        {minTechScore ? <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            onClick={handleSaveTechScoreChange}
+            disabled={passedScore === minTechScore}
+        >
+            Save
+        </Button> : null}
+        <br></br><br></br>
         {snapshotDate ? <MuiPickersUtilsProvider utils={MomentUtils}>
             <KeyboardDateTimePicker
                 format="LLL"

--- a/frontend/react-front/src/components/producer-results.js
+++ b/frontend/react-front/src/components/producer-results.js
@@ -75,7 +75,7 @@ const useStyles = makeStyles((theme) => ({
 
 
 
-const App = ({ results, producers, products, bizdevs, community, producerLogos, producerDomainMap }) => {
+const App = ({ results, producers, products, bizdevs, community, producerLogos, producerDomainMap, minimumTechScore }) => {
   const classes = useStyles();
   // Return Guild Logo
   function logo(owner) {
@@ -101,7 +101,7 @@ const App = ({ results, producers, products, bizdevs, community, producerLogos, 
   // Counts all scores together
   function totalscore(tech, product, bizdev, community) {
     // Set passing score
-    let pass = 120
+    let pass = minimumTechScore
     let sum = parseInt(tech) + product + bizdev + community
     if (sum >= pass) {
       return (

--- a/frontend/react-front/src/components/producerscards.js
+++ b/frontend/react-front/src/components/producerscards.js
@@ -2,7 +2,7 @@ import React from 'react'
 import ProducerResults from './producer-results'
 
 
-const App = ({ results, producers, products, bizdevs, community, producerLogos, producerDomainMap }) => {
+const App = ({ results, producers, products, bizdevs, community, producerLogos, producerDomainMap, minimumTechScore }) => {
   
   return (
     <div>
@@ -15,6 +15,7 @@ const App = ({ results, producers, products, bizdevs, community, producerLogos, 
             community={ community }
             producerLogos={producerLogos}
             producerDomainMap={producerDomainMap}
+            minimumTechScore={minimumTechScore}
        />
     </div>
   )


### PR DESCRIPTION
Pre-save
![Screen Shot 2021-08-07 at 16 23 28](https://user-images.githubusercontent.com/9779954/128611740-bec9150a-24e3-4671-bab2-4e61812117b2.png)
Post-save
![Screen Shot 2021-08-07 at 16 23 59](https://user-images.githubusercontent.com/9779954/128611746-61b9c880-bc3e-4b3b-87d8-ddf2cf3fe013.png)
Console recognition of successful DB update
![Screen Shot 2021-08-07 at 16 23 47](https://user-images.githubusercontent.com/9779954/128611753-9cf57c21-e1a4-4680-b07f-26ed7aa95044.png)

- Create admin settings table to hold admin settings (only minimum tech score for now)
- Fastify functions to read and update admin settings
- Form to display and edit minimum score
- Guilds page relies on minimum score from DB

Note: table has to be created by oiguser or whatever fastify uses as a client, as far as I tested... otherwise it throws a permission error.