### PR TITLE
September update

### DIFF
--- a/frontend/fastify/server.js
+++ b/frontend/fastify/server.js
@@ -39,6 +39,8 @@ fastify.get('/api/snapshottechresults', db.getSnapshotResults)
 fastify.get('/api/results/:owner', db.getResultsbyOwner)
 // Paginated results by owner (requires index & limit in body)
 fastify.get('/api/paginatedresults/:owner', db.getPaginatedResultsByOwner)
+// Monthly average results
+fastify.get('/api/monthlyaverageresults/:owner', db.getAverageMonthlyResult)
 fastify.get('/api/snapshotlatestresults', db.getLatestSnapshotResults)
 // Admin panel related items: snapshot settings (including snapshot date), and point system
 fastify.get('/api/snapshotsettings', db.getSnapshotSettings)

--- a/frontend/react-front/src/App.js
+++ b/frontend/react-front/src/App.js
@@ -192,7 +192,8 @@ const App = (props) => {
                   <Router>
                     <Route path="/latestresults" component={() => <MonthlyResults
                       results={latestresults}
-                      activeGuilds={rawProducers.filter(producer => producer.active === true).map(producer => producer.owner_name)}
+                      activeGuilds={producers.map(producer => producer.owner_name)}
+                      top21Guilds={rawProducers.filter(producer => producer.top21 === true).map(producer => producer.owner_name)}
                     />} exact />
                     <Route exact path="/snapshot" component={() => <SnapshotResults
                       /*results={latestresults}*/

--- a/frontend/react-front/src/components/producer-detail.js
+++ b/frontend/react-front/src/components/producer-detail.js
@@ -246,6 +246,7 @@ const generateServicesProvided = (results, classes) => {
 const App = ({ producer, latestresults, producerLogos, producerDomainMap, activeUser }) => {
   const classes = useStyles();
   const [results, setResults] = useState([]);
+  const [avgResult, setAvgResult] = useState([]);
 
   const preload = 60; // Number of results to preload (21 for 1 page, 42 for 2)
 
@@ -253,6 +254,10 @@ const App = ({ producer, latestresults, producerLogos, producerDomainMap, active
     if (producer) {
       axios.get(api_base + `/api/truncatedPaginatedResults/${producer.owner_name}?index=0&limit=${preload - 1}`).then((response) => {
         setResults(response.data)
+      })
+      // Future-proof: add ?month=x, ?year=y to show results for a particular month
+      axios.get(api_base + `/api/monthlyaverageresults/${producer.owner_name}`).then((response) => {
+        setAvgResult(response.data)
       })
     }
   }, [producer]);
@@ -296,6 +301,7 @@ const App = ({ producer, latestresults, producerLogos, producerDomainMap, active
         <p>{cpuSummary({ results: results.slice(0, 7), latestresults })}</p>
       </Paper> : null}
       {results.length >= 1 ? <h2>Latest Results</h2> : null}
+      {JSON.stringify(avgResult)}
       {results.length >= 1 ? <TechresultTables
         passedResults={results}
         hideOwnerName={true}

--- a/frontend/react-front/src/components/results.js
+++ b/frontend/react-front/src/components/results.js
@@ -1,13 +1,14 @@
 import React from 'react'
 import TechresultTables from './tech-tablelist-results'
 
-const App = ({ results, activeGuilds }) => {
+const App = ({ results, activeGuilds, top21Guilds }) => {
   return (
     <div>
       <h1>Latest Results</h1>
       <TechresultTables
             passedResults={ results }
             activeGuilds={ activeGuilds }
+            top21Guilds={ top21Guilds }
             description="WAX Mainnet"
        />
     </div>

--- a/frontend/react-front/src/components/table-datagrid.js
+++ b/frontend/react-front/src/components/table-datagrid.js
@@ -54,7 +54,7 @@ export default function Table({ tableData, tableTitle, defaultGuild, isAdmin, po
     }
     if (!!columnObj['date_check']) {
       // If there is a date_check field, this is a tech result, and all fields bar comments should be uneditable
-      return (key === "comments" ? "always" : "never")
+      return ((key === "comments" || key === "score") ? "always" : "never")
     } else if (!!columnObj['points_type']) {
       // Points system - make point_type uneditable
       return (key === "points_type" ? "never" : "always")

--- a/frontend/react-front/src/components/tech-tablelist-results.js
+++ b/frontend/react-front/src/components/tech-tablelist-results.js
@@ -47,6 +47,9 @@ const useStyles = makeStyles((theme) => ({
   root: {
     flexGrow: 1,
   },
+  top21: {
+    boxShadow: "0 0 15px 0 rgb(255 220 81) inset"
+  },
   paper: {
     padding: theme.spacing(2),
     backgroundColor: theme.palette.text.primary,
@@ -116,7 +119,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function ResultTables({ passedResults, hideOwnerName, loadMoreResults, activeGuilds }) {
+export default function ResultTables({ passedResults, hideOwnerName, loadMoreResults, activeGuilds, top21Guilds }) {
   // Basic paginaton frontend setup - 21 results
   const initialIndex = 21;
   const [results, setResults] = useState(passedResults);
@@ -224,7 +227,7 @@ export default function ResultTables({ passedResults, hideOwnerName, loadMoreRes
           </TableHead>
           <TableBody>
             {resultSlice.map((result) => {
-              return !hideOwnerName && activeGuilds && activeGuilds.indexOf(result.owner_name) === -1 ? null : <StyledTableRow key={result.key}>
+              return !hideOwnerName && activeGuilds && activeGuilds.indexOf(result.owner_name) === -1 ? null : <StyledTableRow key={result.key} className={(top21Guilds && top21Guilds.indexOf(result.owner_name) !== -1 ? classes.top21 : "")}>
                 {hideOwnerName === true ? null : <StyledTableCell className={classes.ownerName}><a className={classes.waxButton} href={`/guilds/${result.owner_name}`}>{result.owner_name}</a></StyledTableCell>}
                 <StyledTableCell>{iconResult(result.chains_json)}</StyledTableCell>
                 <StyledTableCell>{iconResult(result.wax_json)}</StyledTableCell>

--- a/frontend/react-front/src/components/update-db.js
+++ b/frontend/react-front/src/components/update-db.js
@@ -106,15 +106,15 @@ const updateDb = (operation, type, payload, tableTitle, pointSystem) => {
                 });
         } else if (tableTitle === "Tech Snapshot" || tableTitle === "Snapshot Tech Results") {
             const {
-                owner_name, date_check, comments
+                owner_name, date_check, comments, score
             } = payload;
             axios
                 .post(api_base + "/api/snapshotResultCommentUpdate", {
-                    owner_name, date_check, comments
+                    owner_name, date_check, comments, score: parseFloat(score)
                 })
                 .then(() => {
                     console.log(
-                        `Comments on tech result for ${owner_name} updated! Reload to confirm.`
+                        `Comments and/or score on tech result for ${owner_name} updated! Reload to confirm.`
                     );
                 });
         } else if (tableTitle === "Point System") {


### PR DESCRIPTION
Top 21 guilds are now visually highlighted on the Latest Results page.

![image](https://user-images.githubusercontent.com/6784287/133969268-ac11a0fe-427b-4e13-bb5b-71e77723543b.png)

Scores are now editable, placed for easy access alongside comments, and typo-proof to prevent losing progress if mass-adjusting scores.
![image](https://user-images.githubusercontent.com/6784287/133969285-19c6ae9a-29bf-49cb-b6d0-03f35b1230ad.png)
![image](https://user-images.githubusercontent.com/6784287/133969295-266da6de-d9fc-4c22-b967-06736c9cc8fa.png)

Monthly average result being polished off - scores and CPU times are shown as averages, while boolean checks (e.g. atomic_api) are shown as percentage true / percentage uptime.
![image](https://user-images.githubusercontent.com/6784287/133969320-e72b3ef9-4df9-4340-88bb-46a06d9c5578.png)

Progress being made on a "Wayback Machine" / Meta Snapshot system whereby the entire OIG Portal can be frozen in time and scrolled back on at any time - with all products, bizdevs, tech scores, total scores, comments, and the like being locked, so that it's easy to go back and check how the guilds were doing at a certain time. Backend functionality development has begun, and frontend design is underway.