### PR TITLE
Meta snapshots

### DIFF
--- a/backend/db_changes.sql
+++ b/backend/db_changes.sql
@@ -29,3 +29,64 @@ drop index if exists oig.idx_nodes_types;
 CREATE UNIQUE INDEX idx_nodes_type ON oig.nodes(owner_name, node_type, http_node_url );
 
 
+-- Add metasnapshot_date column
+ALTER TABLE oig.adminsettings ADD COLUMN metasnapshot_date timestamp with time zone;
+ALTER TABLE oig.bizdev ADD COLUMN metasnapshot_date timestamp with time zone;
+ALTER TABLE oig.community ADD COLUMN metasnapshot_date timestamp with time zone;
+ALTER TABLE oig.pointsystem ADD COLUMN metasnapshot_date timestamp with time zone;
+ALTER TABLE oig.producer ADD COLUMN metasnapshot_date timestamp with time zone;
+ALTER TABLE oig.products ADD COLUMN metasnapshot_date timestamp with time zone;
+ALTER TABLE oig.results ADD COLUMN metasnapshot_date timestamp with time zone;
+
+-- Drop all current indexes and primary keys that do not use metasnapshot dates
+DROP INDEX oig.idx_bizdevs_type;
+ALTER TABLE oig.community DROP CONSTRAINT community_pkey;
+ALTER TABLE oig.pointsystem DROP CONSTRAINT pointsystem_pkey;
+ALTER TABLE oig.producer DROP CONSTRAINT producer_pkey;
+DROP INDEX oig.idx_bizdev_type;
+DROP INDEX oig.idx_products_type;
+DROP INDEX oig.idx_results_type;
+
+-- Make replacement indexes using metasnapshot date
+CREATE UNIQUE INDEX adminsettings_idx ON oig.adminsettings(metasnapshot_date);
+CREATE UNIQUE INDEX bizdev_idx ON oig.bizdev(owner_name,name,metasnapshot_date);
+CREATE UNIQUE INDEX community_idx ON oig.community(owner_name,metasnapshot_date);
+CREATE UNIQUE INDEX pointsystem_idx ON oig.pointsystem(points_type,metasnapshot_date);
+CREATE UNIQUE INDEX producer_idx ON oig.producer(owner_name,metasnapshot_date);
+CREATE UNIQUE INDEX product_idx ON oig.products(owner_name,name,metasnapshot_date);
+CREATE UNIQUE INDEX results_idx ON oig.results(owner_name,date_check,metasnapshot_date);
+
+-- Create seed metasnapshot data - minimum tech score
+INSERT INTO oig.adminsettings (minimum_tech_score, metasnapshot_date)
+SELECT minimum_tech_score, CURRENT_DATE
+FROM oig.adminsettings WHERE metasnapshot_date IS NULL
+
+-- Create seed metasnapshot data - bizdevs (primarily used to freeze comments)
+INSERT INTO oig.bizdev (owner_name, name, description, stage, analytics_url, spec_url, score, date_updated, points, comments, metasnapshot_date)
+SELECT owner_name, name, description, stage, analytics_url, spec_url, score, date_updated, points, comments, CURRENT_DATE
+FROM oig.bizdev WHERE metasnapshot_date IS NULL
+
+-- Create seed metasnapshot data - community (primarily used to freeze comments)
+INSERT INTO oig.community (owner_name, origcontentpoints, transcontentpoints, eventpoints, managementpoints, outstandingpoints, score, date_updated, comments, metasnapshot_date)
+SELECT owner_name, origcontentpoints, transcontentpoints, eventpoints, managementpoints, outstandingpoints, score, date_updated, comments, CURRENT_DATE
+FROM oig.community WHERE metasnapshot_date IS NULL
+
+-- Create seed metasnapshot data - pointsystem (used to reference old scoring criteria)
+INSERT INTO oig.pointsystem (points_type, points, multiplier, min_requirements, metasnapshot_date)
+SELECT points_type, points, multiplier, min_requirements, CURRENT_DATE
+FROM oig.pointsystem WHERE metasnapshot_date IS NULL
+
+-- Create seed metasnapshot data - producer (used to reference historical top21 guilds)
+INSERT INTO oig.producer (owner_name, candidate, url, jsonurl, chainsurl, active, logo_svg, top21, country_code, account_name, metasnapshot_date)
+SELECT owner_name, candidate, url, jsonurl, chainsurl, active, logo_svg, top21, country_code, account_name, CURRENT_DATE
+FROM oig.producer WHERE metasnapshot_date IS NULL
+
+-- Create seed metasnapshot data - products (primarily used to freeze comments)
+INSERT INTO oig.products (owner_name, name, description, stage, analytics_url, spec_url, code_repo, score, date_updated, points, comments, metasnapshot_date)
+SELECT owner_name, name, description, stage, analytics_url, spec_url, code_repo, score, date_updated, points, comments, CURRENT_DATE
+FROM oig.products WHERE metasnapshot_date IS NULL
+
+-- Create seed metasnapshot data - tech results (primarily used to freeze comments)
+INSERT INTO oig.results (owner_name, cors_check, cors_check_error, http_check, http_check_error, https_check, https_check_error, http2_check, http2_check_error, full_history, full_history_error, snapshots, snapshots_error, seed_node, seed_node_error, api_node, api_node_error, oracle_feed, oracle_feed_error, wax_json, chains_json, cpu_time, date_check, score, tls_check, tls_check_error, cpu_avg, snapshot_date, hyperion_v2, hyperion_v2_error, producer_api_error, producer_api_check, net_api_check, net_api_error, dbsize_api_check, dbsize_api_error, comments, atomic_api, atomic_api_error, metasnapshot_date)
+SELECT DISTINCT ON (owner_name) owner_name, cors_check, cors_check_error, http_check, http_check_error, https_check, https_check_error, http2_check, http2_check_error, full_history, full_history_error, snapshots, snapshots_error, seed_node, seed_node_error, api_node, api_node_error, oracle_feed, oracle_feed_error, wax_json, chains_json, cpu_time, date_check, score, tls_check, tls_check_error, cpu_avg, snapshot_date, hyperion_v2, hyperion_v2_error, producer_api_error, producer_api_check, net_api_check, net_api_error, dbsize_api_check, dbsize_api_error, comments, atomic_api, atomic_api_error, CURRENT_DATE 
+FROM oig.results WHERE snapshot_date IS NOT NULL AND metasnapshot_date IS NULL ORDER BY owner_name, snapshot_date DESC

--- a/backend/db_changes.sql
+++ b/backend/db_changes.sql
@@ -59,34 +59,34 @@ CREATE UNIQUE INDEX results_idx ON oig.results(owner_name,date_check,metasnapsho
 -- Create seed metasnapshot data - minimum tech score
 INSERT INTO oig.adminsettings (minimum_tech_score, metasnapshot_date)
 SELECT minimum_tech_score, CURRENT_DATE
-FROM oig.adminsettings WHERE metasnapshot_date IS NULL
+FROM oig.adminsettings WHERE metasnapshot_date IS NULL;
 
 -- Create seed metasnapshot data - bizdevs (primarily used to freeze comments)
 INSERT INTO oig.bizdev (owner_name, name, description, stage, analytics_url, spec_url, score, date_updated, points, comments, metasnapshot_date)
 SELECT owner_name, name, description, stage, analytics_url, spec_url, score, date_updated, points, comments, CURRENT_DATE
-FROM oig.bizdev WHERE metasnapshot_date IS NULL
+FROM oig.bizdev WHERE metasnapshot_date IS NULL;
 
 -- Create seed metasnapshot data - community (primarily used to freeze comments)
 INSERT INTO oig.community (owner_name, origcontentpoints, transcontentpoints, eventpoints, managementpoints, outstandingpoints, score, date_updated, comments, metasnapshot_date)
 SELECT owner_name, origcontentpoints, transcontentpoints, eventpoints, managementpoints, outstandingpoints, score, date_updated, comments, CURRENT_DATE
-FROM oig.community WHERE metasnapshot_date IS NULL
+FROM oig.community WHERE metasnapshot_date IS NULL;
 
 -- Create seed metasnapshot data - pointsystem (used to reference old scoring criteria)
 INSERT INTO oig.pointsystem (points_type, points, multiplier, min_requirements, metasnapshot_date)
 SELECT points_type, points, multiplier, min_requirements, CURRENT_DATE
-FROM oig.pointsystem WHERE metasnapshot_date IS NULL
+FROM oig.pointsystem WHERE metasnapshot_date IS NULL;
 
 -- Create seed metasnapshot data - producer (used to reference historical top21 guilds)
 INSERT INTO oig.producer (owner_name, candidate, url, jsonurl, chainsurl, active, logo_svg, top21, country_code, account_name, metasnapshot_date)
 SELECT owner_name, candidate, url, jsonurl, chainsurl, active, logo_svg, top21, country_code, account_name, CURRENT_DATE
-FROM oig.producer WHERE metasnapshot_date IS NULL
+FROM oig.producer WHERE metasnapshot_date IS NULL;
 
 -- Create seed metasnapshot data - products (primarily used to freeze comments)
 INSERT INTO oig.products (owner_name, name, description, stage, analytics_url, spec_url, code_repo, score, date_updated, points, comments, metasnapshot_date)
 SELECT owner_name, name, description, stage, analytics_url, spec_url, code_repo, score, date_updated, points, comments, CURRENT_DATE
-FROM oig.products WHERE metasnapshot_date IS NULL
+FROM oig.products WHERE metasnapshot_date IS NULL;
 
 -- Create seed metasnapshot data - tech results (primarily used to freeze comments)
 INSERT INTO oig.results (owner_name, cors_check, cors_check_error, http_check, http_check_error, https_check, https_check_error, http2_check, http2_check_error, full_history, full_history_error, snapshots, snapshots_error, seed_node, seed_node_error, api_node, api_node_error, oracle_feed, oracle_feed_error, wax_json, chains_json, cpu_time, date_check, score, tls_check, tls_check_error, cpu_avg, snapshot_date, hyperion_v2, hyperion_v2_error, producer_api_error, producer_api_check, net_api_check, net_api_error, dbsize_api_check, dbsize_api_error, comments, atomic_api, atomic_api_error, metasnapshot_date)
 SELECT DISTINCT ON (owner_name) owner_name, cors_check, cors_check_error, http_check, http_check_error, https_check, https_check_error, http2_check, http2_check_error, full_history, full_history_error, snapshots, snapshots_error, seed_node, seed_node_error, api_node, api_node_error, oracle_feed, oracle_feed_error, wax_json, chains_json, cpu_time, date_check, score, tls_check, tls_check_error, cpu_avg, snapshot_date, hyperion_v2, hyperion_v2_error, producer_api_error, producer_api_check, net_api_check, net_api_error, dbsize_api_check, dbsize_api_error, comments, atomic_api, atomic_api_error, CURRENT_DATE 
-FROM oig.results WHERE snapshot_date IS NOT NULL AND metasnapshot_date IS NULL ORDER BY owner_name, snapshot_date DESC
+FROM oig.results WHERE snapshot_date IS NOT NULL AND metasnapshot_date IS NULL ORDER BY owner_name, snapshot_date DESC;

--- a/frontend/fastify/pgquery.js
+++ b/frontend/fastify/pgquery.js
@@ -120,7 +120,7 @@ const updatePointSystem = (request, reply) => {
   const toUpdate = (multiplier ? "multiplier=" + multiplier : "") + (points && multiplier ? ", " : "") + (points ? "points=" + points : "");
 
   client.query(
-    `UPDATE oig.pointsystem SET ${toUpdate} WHERE points_type= $1`,
+    `UPDATE oig.pointsystem SET ${toUpdate} WHERE points_type= $1 AND metasnapshot_date IS NULL`,
     [points_type],
     (error, results) => {
       if (error) {
@@ -331,7 +331,7 @@ const updateProducer = (request, reply) => {
   const owner = request.params.owner
   const { account_name, active } = request.body
 
-  client.query('UPDATE oig.producer SET "active" = $1, "account_name" = $2 WHERE "owner_name" = $3', [active, account_name, owner], (error, results) => {
+  client.query('UPDATE oig.producer SET "active" = $1, "account_name" = $2 WHERE "owner_name" = $3 AND metasnapshot_date IS NULL', [active, account_name, owner], (error, results) => {
     if (error) {
       throw error
     }

--- a/frontend/fastify/server.js
+++ b/frontend/fastify/server.js
@@ -77,6 +77,7 @@ fastify.get('/api/truncatedPaginatedResults/:owner', db.getTruncatedPaginatedRes
 // Admin settings - just minimum tech score for now
 fastify.get('/api/getAdminSettings', db.getAdminSettings)
 fastify.post('/api/updateAdminSettings', db.updateAdminSettings)
+fastify.post('/api/addMetaSnapshot', db.addMetaSnapshot)
 
 // Starts the Fastify Server //
 const start = async () => {

--- a/frontend/react-front/src/App.js
+++ b/frontend/react-front/src/App.js
@@ -95,8 +95,8 @@ const App = (props) => {
     const month = date.substring(5, 7);
     const day = date.substring(8, 10);
     const short = `${monthMap[month]}/${year.substring(2, 4)}`;
-    alert("Meta-snapshot options: " + availableMetaSnapshots.join(", "));
-    //setMetaSnapshotDate({year, month, day, short})
+    console.log("Meta-snapshot options: " + availableMetaSnapshots.join(", "));
+    setMetaSnapshotDate({year, month, day, short, date})
   }
 
   const openTimeMachine = () => {
@@ -248,6 +248,7 @@ const App = (props) => {
                       producerLogos={producerLogos}
                       producerDomainMap={producerDomainMap}
                       activeGuilds={rawProducers.filter(producer => producer.active === true).map(producer => producer.owner_name)}
+                      metaSnapshotDate={metaSnapshotDate}
                     />} />
                     <Route exact path="/" component={() =>
                       <ProducerCards results={latestresults}
@@ -261,7 +262,7 @@ const App = (props) => {
                       />} />
                     <Route exact path='/guilds/:ownername' component={BPwithownername} />
                     <Route exact path='/form' component={() => <Testform producers={producers} isAdmin={adminOverride || (props.ual.activeUser && admins.indexOf(props.ual.activeUser.accountName) !== -1)} />} />
-                    <Route exact path='/admin' component={() => <AdminPanel snapshotSettings={snapshotSettings} producers={rawProducers} pointSystem={rawPointSystem} isAdmin={adminOverride || (props.ual.activeUser && admins.indexOf(props.ual.activeUser.accountName) !== -1)} minimumTechScore={minimumTechScore} />} />
+                    <Route exact path='/admin' component={() => <AdminPanel snapshotSettings={snapshotSettings} producers={rawProducers} pointSystem={rawPointSystem} isAdmin={adminOverride || (props.ual.activeUser && admins.indexOf(props.ual.activeUser.accountName) !== -1)} minimumTechScore={minimumTechScore} metaSnapshotDate={metaSnapshotDate} />} />
                   </Router>
                 </Paper>
               </Grid>

--- a/frontend/react-front/src/App.js
+++ b/frontend/react-front/src/App.js
@@ -170,6 +170,8 @@ const App = (props) => {
           producerLogos={producerLogos}
           producerDomainMap={producerDomainMap}
           activeUser={props.ual.activeUser}
+          //metaSnapshotDate={{month: 9, year: 2021, short: 'Sep/21'}}
+          openTimeMachine={() => {alert("Open Time Machine")}}
         />
       </>
     );

--- a/frontend/react-front/src/App.js
+++ b/frontend/react-front/src/App.js
@@ -71,7 +71,41 @@ const App = (props) => {
   const [snapshotSettings, setSnapshotSettings] = useState([])
   const [rawPointSystem, setRawPointSystem] = useState([])
   const [pointSystem, setPointSystem] = useState([])
-  const [minimumTechScore, setMinimumTechScore] = useState([]);
+  const [minimumTechScore, setMinimumTechScore] = useState(999);
+  const [metaSnapshotDate, setMetaSnapshotDate] = useState(null);
+  const [availableMetaSnapshots, setAvailableMetaSnapshots] = useState([])
+
+  const monthMap = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec"
+  ]
+
+  const updateMetaSnapshotDate = (date) => {
+    const year = date.substring(0, 4);
+    const month = date.substring(5, 7);
+    const day = date.substring(8, 10);
+    const short = `${monthMap[month]}/${year.substring(2, 4)}`;
+    alert("Meta-snapshot options: " + availableMetaSnapshots.join(", "));
+    //setMetaSnapshotDate({year, month, day, short})
+  }
+
+  const openTimeMachine = () => {
+    if (availableMetaSnapshots.length >= 1) {
+      updateMetaSnapshotDate(availableMetaSnapshots[0])
+    } else {
+      alert("Loading meta-snapshots... please wait.")
+    }
+  }
 
   useEffect(() => {
     // Load data and set hooks. A future implementation could use axios.all
@@ -118,6 +152,9 @@ const App = (props) => {
     })
     axios.get(api_base + '/api/getAdminSettings').then((response) => {
       const data = response.data;
+      const availableMetaSnapshots = data.filter(row => !!row.metasnapshot_date).map(row => row.metasnapshot_date.substring(0, 10));
+      setAvailableMetaSnapshots(availableMetaSnapshots);
+      console.log("Set available meta-snapshots")
       const minScore = data && data[0] && data[0].minimum_tech_score ? data[0].minimum_tech_score : 999;
       setMinimumTechScore(minScore)
     });
@@ -170,8 +207,8 @@ const App = (props) => {
           producerLogos={producerLogos}
           producerDomainMap={producerDomainMap}
           activeUser={props.ual.activeUser}
-          //metaSnapshotDate={{month: 9, year: 2021, short: 'Sep/21'}}
-          openTimeMachine={() => {alert("Open Time Machine")}}
+          metaSnapshotDate={metaSnapshotDate}
+          openTimeMachine={openTimeMachine}
         />
       </>
     );
@@ -187,6 +224,8 @@ const App = (props) => {
               activeUser={props.ual.activeUser}
               loginModal={props.ual.showModal}
               logOut={props.ual.logout}
+              metaSnapshotDate={metaSnapshotDate}
+              openTimeMachine={openTimeMachine}
               isAdmin={adminOverride || (props.ual.activeUser && admins.indexOf(props.ual.activeUser.accountName) !== -1)} />
             <Grid container spacing={3}>
               <Grid item xs={12}>

--- a/frontend/react-front/src/App.js
+++ b/frontend/react-front/src/App.js
@@ -13,7 +13,7 @@ import Testform from './components/monthly-updates'
 import AdminPanel from './components/admin'
 import Container from '@material-ui/core/Container';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import { api_base } from './config'
+import { api_base, admin_override } from './config'
 // import {addScoreToItem} from './functions/scoring'
 
 //import 'fontsource-roboto';
@@ -51,7 +51,7 @@ const App = (props) => {
     "sentnlagents"
   ]
 
-  const adminOverride = false;
+  const adminOverride = admin_override; // Whether to require wallet authentication to access admin features.
 
   const classes = useStyles();
   // const [rawResults, setRawResults] = useState([])

--- a/frontend/react-front/src/components/admin.js
+++ b/frontend/react-front/src/components/admin.js
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme) => ({
     }
 }))
 
-const AdminPanel = ({ snapshotSettings, producers, pointSystem, isAdmin, minimumTechScore }) => {
+const AdminPanel = ({ snapshotSettings, producers, pointSystem, isAdmin, minimumTechScore, metaSnapshotDate }) => {
     const classes = useStyles();
     const [snapshotDate, updateSnapshotDate] = useState(null);
     const [passedScore, updatePassedScore] = useState(120)
@@ -45,6 +45,14 @@ const AdminPanel = ({ snapshotSettings, producers, pointSystem, isAdmin, minimum
 
     const handleTechScoreChange = (event) => {
         updateMinTechScore(event.target.value)
+    }
+
+    const triggerMetaSnapshot = () => {
+        axios.post(api_base + "/api/addMetaSnapshot").then((response) => {
+            alert(response.data)
+        }).catch(err => {
+            alert(err.response.data)
+        })
     }
 
     const handleSaveTechScoreChange = () => {
@@ -67,7 +75,8 @@ const AdminPanel = ({ snapshotSettings, producers, pointSystem, isAdmin, minimum
             return {
                 guild_name: producer.owner_name,
                 account_name: producer.account_name,
-                active: producer.active === true ? "true" : producer.active === false ? "false" : ""
+                active: producer.active === true ? "true" : producer.active === false ? "false" : "",
+                metasnapshot_date: producer.metasnapshot_date
             }
         } else {
             return null
@@ -80,6 +89,13 @@ const AdminPanel = ({ snapshotSettings, producers, pointSystem, isAdmin, minimum
         } else {
             setCurrentTable("pointSystem")
         }
+    }
+
+    const filterMetaSnapshots = (rows) => {
+        if (!!metaSnapshotDate) {
+            return rows.filter(row => row.metasnapshot_date && row.metasnapshot_date.substring(0, 10) === metaSnapshotDate.date)
+        }
+        return rows.filter(row => row.metasnapshot_date === null || row.metasnapshot_date === undefined)
     }
 
     return isAdmin ? <div className={classes.root}>
@@ -95,6 +111,15 @@ const AdminPanel = ({ snapshotSettings, producers, pointSystem, isAdmin, minimum
         >
             Save
         </Button> : null}
+        <br></br><br></br>
+        <Button
+            type="submit"
+            variant="contained"
+            color="primary"
+            onClick={triggerMetaSnapshot}
+        >
+            Trigger Meta Snapshot
+        </Button>
         <br></br><br></br>
         {snapshotDate ? <MuiPickersUtilsProvider utils={MomentUtils}>
             <KeyboardDateTimePicker
@@ -122,14 +147,14 @@ const AdminPanel = ({ snapshotSettings, producers, pointSystem, isAdmin, minimum
         <br></br><br></br>
         <div className={currentTable === "guildSettings" ? classes.hidden : null}>
             <TableDataGrid
-                tableData={pointSystem}
+                tableData={filterMetaSnapshots(pointSystem)}
                 tableTitle="Point System"
                 isAdmin={isAdmin}
             />
         </div>
         <div className={currentTable === "pointSystem" ? classes.hidden : null}>
             <TableDataGrid
-                tableData={guildSettings}
+                tableData={filterMetaSnapshots(guildSettings)}
                 tableTitle="Guild Settings"
                 isAdmin={isAdmin}
             />

--- a/frontend/react-front/src/components/appbar.js
+++ b/frontend/react-front/src/components/appbar.js
@@ -95,7 +95,7 @@ const useStyles = makeStyles((theme) => ({
 
 
 
-export default function ButtonAppBar({ activeUser, loginModal, logOut, isAdmin }) {
+export default function ButtonAppBar({ activeUser, loginModal, logOut, isAdmin, metaSnapshotDate, openTimeMachine }) {
   const classes = useStyles();
 
   return (
@@ -114,6 +114,9 @@ export default function ButtonAppBar({ activeUser, loginModal, logOut, isAdmin }
             OIG Portal
           </Typography>
           <nav className={classes.linkContainer}>
+            <Link variant="button" color="inherit" href="#" onClick={openTimeMachine} className={[classes.link, classes.waxButton]}>
+              {metaSnapshotDate ? metaSnapshotDate.short : "Time Machine"}
+            </Link>
             <Link underline="none" variant="button" color="inherit" href="/" className={classes.link}>
               Home
             </Link>

--- a/frontend/react-front/src/components/producer-detail.js
+++ b/frontend/react-front/src/components/producer-detail.js
@@ -243,7 +243,7 @@ const generateServicesProvided = (results, classes) => {
   return jsx
 }
 
-const App = ({ producer, latestresults, producerLogos, producerDomainMap, activeUser }) => {
+const App = ({ producer, latestresults, producerLogos, producerDomainMap, activeUser, metaSnapshotDate, openTimeMachine }) => {
   const classes = useStyles();
   const [results, setResults] = useState([]);
   const [avgResult, setAvgResult] = useState([]);
@@ -256,7 +256,7 @@ const App = ({ producer, latestresults, producerLogos, producerDomainMap, active
         setResults(response.data)
       })
       // Future-proof: add ?month=x, ?year=y to show results for a particular month
-      axios.get(api_base + `/api/monthlyaverageresults/${producer.owner_name}`).then((response) => {
+      axios.get(api_base + `/api/monthlyaverageresults/${producer.owner_name}${metaSnapshotDate ? `?month=${metaSnapshotDate.month}&year=${metaSnapshotDate.year}` : ''}`).then((response) => {
         setAvgResult(response.data)
       })
     }
@@ -301,9 +301,11 @@ const App = ({ producer, latestresults, producerLogos, producerDomainMap, active
         <p>{cpuSummary({ results: results.slice(0, 7), latestresults })}</p>
       </Paper> : null}
       {results.length >= 1 ? <h2>Latest Results</h2> : null}
-      {JSON.stringify(avgResult)}
       {results.length >= 1 ? <TechresultTables
         passedResults={results}
+        avgResult={avgResult}
+        metaSnapshotDate={metaSnapshotDate}
+        openTimeMachine={openTimeMachine}
         hideOwnerName={true}
         loadMoreResults={loadMoreResults}
       /> : null}

--- a/frontend/react-front/src/components/producer-detail.js
+++ b/frontend/react-front/src/components/producer-detail.js
@@ -256,11 +256,11 @@ const App = ({ producer, latestresults, producerLogos, producerDomainMap, active
         setResults(response.data)
       })
       // Future-proof: add ?month=x, ?year=y to show results for a particular month
-      axios.get(api_base + `/api/monthlyaverageresults/${producer.owner_name}${metaSnapshotDate ? `?month=${metaSnapshotDate.month}&year=${metaSnapshotDate.year}` : ''}`).then((response) => {
+      axios.get(api_base + `/api/monthlyaverageresults/${producer.owner_name}${!!metaSnapshotDate ? `?month=${metaSnapshotDate.month}&year=${metaSnapshotDate.year}` : ''}`).then((response) => {
         setAvgResult(response.data)
       })
     }
-  }, [producer]);
+  }, [producer, metaSnapshotDate]);
 
 
   const loadMoreResults = async (index, limit) => {

--- a/frontend/react-front/src/components/snapshot-results.js
+++ b/frontend/react-front/src/components/snapshot-results.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import moment from 'moment'
 import { makeStyles } from '@material-ui/core/styles';
 import { Button } from '@material-ui/core';
-import {SnapshotScoring} from './snapshot-scoring'
+import { SnapshotScoring } from './snapshot-scoring'
 import IntegratedScores from './integrated-snapshot-scores'
 
 const useStyles = makeStyles((theme) => ({
@@ -14,9 +14,9 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
-const App = ({ /*results, */ producers, products, bizdevs, community, snapresults, pointSystem, isAdmin, producerLogos, producerDomainMap, activeGuilds }) => {
+const App = ({ /*results, */ producers, products, bizdevs, community, snapresults, pointSystem, isAdmin, producerLogos, producerDomainMap, activeGuilds, metaSnapshotDate }) => {
   const classes = useStyles();
-  
+
   const [viewType, setViewType] = useState('integrated')
   const lastfetched = !!snapresults && !!snapresults[0] && !!snapresults[0].snapshot_date ? moment(snapresults[0].snapshot_date).fromNow() : 'never';
 
@@ -28,14 +28,21 @@ const App = ({ /*results, */ producers, products, bizdevs, community, snapresult
     }
   }
 
+  const filterMetaSnapshots = (rows) => {
+    if (!!metaSnapshotDate) {
+      return rows.filter(row => row.metasnapshot_date && row.metasnapshot_date.substring(0, 10) === metaSnapshotDate.date)
+    }
+    return rows.filter(row => row.metasnapshot_date === null || row.metasnapshot_date === undefined)
+  }
+
   const loadView = () => {
     if (viewType === 'individual') {
       return <SnapshotScoring
-        results={snapresults}
-        producers={producers}
-        products={products}
-        bizdevs={bizdevs}
-        community={community}
+        results={filterMetaSnapshots(snapresults)}
+        producers={filterMetaSnapshots(producers)}
+        products={filterMetaSnapshots(products)}
+        bizdevs={filterMetaSnapshots(bizdevs)}
+        community={filterMetaSnapshots(community)}
         pointSystem={pointSystem}
         isAdmin={isAdmin}
         producerLogos={producerLogos}
@@ -44,11 +51,11 @@ const App = ({ /*results, */ producers, products, bizdevs, community, snapresult
     }
     if (viewType === 'integrated') {
       return <IntegratedScores
-        results={snapresults}
-        producers={producers}
-        products={products}
-        bizdevs={bizdevs}
-        community={community}
+        results={filterMetaSnapshots(snapresults)}
+        producers={filterMetaSnapshots(producers)}
+        products={filterMetaSnapshots(products)}
+        bizdevs={filterMetaSnapshots(bizdevs)}
+        community={filterMetaSnapshots(community)}
         pointSystem={pointSystem}
         isAdmin={isAdmin}
         producerLogos={producerLogos}

--- a/frontend/react-front/src/components/table-datagrid.js
+++ b/frontend/react-front/src/components/table-datagrid.js
@@ -49,7 +49,7 @@ export default function Table({ tableData, tableTitle, defaultGuild, isAdmin, po
   }
 
   const isEditable = (key, columnObj) => {
-    if (!isAdmin) {
+    if (!isAdmin || columnObj['metasnapshot_date'] !== null) {
       return 'never'
     }
     if (!!columnObj['date_check']) {
@@ -83,7 +83,7 @@ export default function Table({ tableData, tableTitle, defaultGuild, isAdmin, po
         field: key,
         align: 'left',
         // Hide owner_name
-        hidden: key === "owner_name" || (key === "comments" && !isAdmin),
+        hidden: key === "owner_name" || (key === "comments" && !isAdmin) || key === "metasnapshot_date",
         // Make certain fields uneditable
         editable: (isEditable(key, columnObj)),
         // Highlight comments
@@ -110,23 +110,23 @@ export default function Table({ tableData, tableTitle, defaultGuild, isAdmin, po
           ],
           padding: 'dense'
         }}
-        actions={isAdmin && type !== 'unknownType' && tableTitle !== 'Point System' ? [
+        actions={!tableState[0].metasnapshot_date && isAdmin && type !== 'unknownType' && tableTitle !== 'Point System' ? [
           { // Only show recalc points for product, biz, and comm - though we may want to add this to tech results?
             icon: 'refresh',
             tooltip: 'Recalculate Score',
             onClick: (event, currentRow) => tryUpdateTable('recalc', currentRow, tableTitle, tableState, setTableState, type, pointSystem)
           }
-        ] : isAdmin && tableTitle === 'Guild Settings' ? [
+        ] : !tableState[0].metasnapshot_date && isAdmin && tableTitle === 'Guild Settings' ? [
           {
             icon: 'visibility',
             tooltip: 'Set Active/Inactive',
             onClick: (event, currentRow) => tryUpdateTable('toggleActive', currentRow, tableTitle, tableState, setTableState)
           }
         ] : null}
-        editable={isAdmin && type !== 'unknownType' ? { // Show only for admins
+        editable={!tableState[0].metasnapshot_date && isAdmin && type !== 'unknownType' ? { // Show only for admins
           onRowUpdate: (newRow, currentRow) => tryUpdateTable('update', currentRow, tableTitle, tableState, setTableState, type, pointSystem, newRow),
           onRowDelete: (currentRow) => tryUpdateTable('delete', currentRow, tableTitle, tableState, setTableState, type),
-        } : isAdmin ? { // No delete for snapshot tech results or point system
+        } : !tableState[0].metasnapshot_date && isAdmin ? { // No delete for snapshot tech results or point system
           onRowUpdate: (newRow, currentRow) => tryUpdateTable('update', currentRow, tableTitle, tableState, setTableState, type, pointSystem, newRow)
         } : false}
         // The below code is terrible, but it has to be this way: https://github.com/mbrn/material-table/issues/1900

--- a/frontend/react-front/src/components/tech-tablelist-results.js
+++ b/frontend/react-front/src/components/tech-tablelist-results.js
@@ -89,6 +89,8 @@ const useStyles = makeStyles((theme) => ({
   waxButton: {
     textDecoration: 'none',
     color: '#332b1f',
+    border: 'none',
+    cursor: 'pointer',
     borderRadius: '100px',
     fontWeight: 'bold',
     padding: '15px 20px',
@@ -117,9 +119,23 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.getContrastText(green[500]),
     backgroundColor: green[500],
   },
+  avgResultCell: {
+    padding: '2px !important',
+    background: 'linear-gradient(90.08deg, rgb(247, 142, 30), rgb(255, 220, 81) 236.03%)',
+    borderLeft: 'rgb(247, 142, 30) !important',
+    borderBottom: 'rgb(255, 220, 81)',
+    '& span': {
+      fontWeight: 'bold',
+      color: '#332b1f',
+      //borderRadius: '100%',
+      display: 'inline-block',
+      padding: '10px 5px',
+      minWidth: '30px'
+    }
+  }
 }));
 
-export default function ResultTables({ passedResults, hideOwnerName, loadMoreResults, activeGuilds, top21Guilds }) {
+export default function ResultTables({ passedResults, avgResult, metaSnapshotDate, hideOwnerName, loadMoreResults, activeGuilds, top21Guilds, openTimeMachine }) {
   // Basic paginaton frontend setup - 21 results
   const initialIndex = 21;
   const [results, setResults] = useState(passedResults);
@@ -226,6 +242,53 @@ export default function ResultTables({ passedResults, hideOwnerName, loadMoreRes
             </TableRow>
           </TableHead>
           <TableBody>
+          {hideOwnerName !== true || !avgResult ? null : <StyledTableRow>
+              <HtmlTooltip title={`${avgResult.chains_json_count}/${avgResult.total_count}`} aria-label="chains_json_count" placement="top">
+                <StyledTableCell className={classes.avgResultCell}><span>{avgResult.chains_json_pct}</span></StyledTableCell>
+              </HtmlTooltip>
+              <HtmlTooltip title={`${avgResult.wax_json_count}/${avgResult.total_count}`} aria-label="wax_json_count" placement="top">
+                <StyledTableCell className={classes.avgResultCell}><span>{avgResult.wax_json_pct}</span></StyledTableCell>
+              </HtmlTooltip>
+              <HtmlTooltip title={`${avgResult.api_node_count}/${avgResult.total_count}`} aria-label="api_node_count" placement="top">
+                <StyledTableCell className={classes.avgResultCell}><span>{avgResult.api_node_pct}</span></StyledTableCell>
+              </HtmlTooltip>
+              <HtmlTooltip title={`${avgResult.seed_node_count}/${avgResult.total_count}`} aria-label="seed_node_count" placement="top">
+                <StyledTableCell className={classes.avgResultCell}><span>{avgResult.seed_node_pct}</span></StyledTableCell>
+              </HtmlTooltip>
+              <HtmlTooltip title={`${avgResult.http_check_count}/${avgResult.total_count}`} aria-label="http_check_count" placement="top">
+                <StyledTableCell className={classes.avgResultCell}><span>{avgResult.http_check_pct}</span></StyledTableCell>
+              </HtmlTooltip>
+              <HtmlTooltip title={`${avgResult.https_check_count}/${avgResult.total_count}`} aria-label="https_check_count" placement="top">
+                <StyledTableCell className={classes.avgResultCell}><span>{avgResult.https_check_pct}</span></StyledTableCell>
+              </HtmlTooltip>
+              <HtmlTooltip title={`${avgResult.tls_ver_count}/${avgResult.total_count}`} aria-label="tls_ver_count" placement="top">
+                <StyledTableCell className={classes.avgResultCell}><span>{avgResult.tls_ver_pct}</span></StyledTableCell>
+              </HtmlTooltip>
+              <HtmlTooltip title={`${avgResult.http2_check_count}/${avgResult.total_count}`} aria-label="http2_check_count" placement="top">
+                <StyledTableCell className={classes.avgResultCell}><span>{avgResult.http2_check_pct}</span></StyledTableCell>
+              </HtmlTooltip>
+              <HtmlTooltip title={`${avgResult.history_v1_count}/${avgResult.total_count}`} aria-label="history_v1_count" placement="top">
+                <StyledTableCell className={classes.avgResultCell}><span>{avgResult.history_v1_pct}</span></StyledTableCell>
+              </HtmlTooltip>
+              <HtmlTooltip title={`${avgResult.hyperion_v2_count}/${avgResult.total_count}`} aria-label="hyperion_v2_count" placement="top">
+                <StyledTableCell className={classes.avgResultCell}><span>{avgResult.hyperion_v2_pct}</span></StyledTableCell>
+              </HtmlTooltip>
+              <HtmlTooltip title={`${avgResult.atomic_api_count}/${avgResult.total_count}`} aria-label="atomic_api_count" placement="top">
+                <StyledTableCell className={classes.avgResultCell}><span>{avgResult.atomic_api_pct}</span></StyledTableCell>
+              </HtmlTooltip>
+              <HtmlTooltip title={`${avgResult.cors_check_count}/${avgResult.total_count}`} aria-label="cors_check_count" placement="top">
+                <StyledTableCell className={classes.avgResultCell}><span>{avgResult.cors_check_pct}</span></StyledTableCell>
+              </HtmlTooltip>
+              <HtmlTooltip title={`${avgResult.oracle_feed_count}/${avgResult.total_count}`} aria-label="oracle_feed_count" placement="top">
+                <StyledTableCell className={classes.avgResultCell}><span>{avgResult.oracle_feed_pct}</span></StyledTableCell>
+              </HtmlTooltip>
+              <HtmlTooltip title={`${avgResult.snapshots_count}/${avgResult.total_count}`} aria-label="snapshots_count" placement="top">
+                <StyledTableCell className={classes.avgResultCell}><span>{avgResult.snapshots_pct}</span></StyledTableCell>
+              </HtmlTooltip>
+              <StyledTableCell className={classes.avgResultCell}><span>{parseInt(avgResult.cpu_avg*100)/100}</span></StyledTableCell>
+              <StyledTableCell className={classes.avgResultCell}><span>{parseInt(avgResult.score_avg)}</span></StyledTableCell>
+              <StyledTableCell className={classes.ownerName}><button className={classes.waxButton} onClick={openTimeMachine}>{metaSnapshotDate ? metaSnapshotDate.short : "Latest"}</button></StyledTableCell>
+            </StyledTableRow>}
             {resultSlice.map((result) => {
               return !hideOwnerName && activeGuilds && activeGuilds.indexOf(result.owner_name) === -1 ? null : <StyledTableRow key={result.key} className={(top21Guilds && top21Guilds.indexOf(result.owner_name) !== -1 ? classes.top21 : "")}>
                 {hideOwnerName === true ? null : <StyledTableCell className={classes.ownerName}><a className={classes.waxButton} href={`/guilds/${result.owner_name}`}>{result.owner_name}</a></StyledTableCell>}

--- a/frontend/react-front/src/components/tech-tablelist-results.js
+++ b/frontend/react-front/src/components/tech-tablelist-results.js
@@ -287,7 +287,7 @@ export default function ResultTables({ passedResults, avgResult, metaSnapshotDat
               </HtmlTooltip>
               <StyledTableCell className={classes.avgResultCell}><span>{parseInt(avgResult.cpu_avg*100)/100}</span></StyledTableCell>
               <StyledTableCell className={classes.avgResultCell}><span>{parseInt(avgResult.score_avg)}</span></StyledTableCell>
-              <StyledTableCell className={classes.ownerName}><button className={classes.waxButton} onClick={openTimeMachine}>{metaSnapshotDate ? metaSnapshotDate.short : "Latest"}</button></StyledTableCell>
+              <StyledTableCell className={classes.ownerName}><button className={classes.waxButton} onClick={openTimeMachine}>{metaSnapshotDate ? metaSnapshotDate.short : "Time Machine"}</button></StyledTableCell>
             </StyledTableRow>}
             {resultSlice.map((result) => {
               return !hideOwnerName && activeGuilds && activeGuilds.indexOf(result.owner_name) === -1 ? null : <StyledTableRow key={result.key} className={(top21Guilds && top21Guilds.indexOf(result.owner_name) !== -1 ? classes.top21 : "")}>

--- a/frontend/react-front/src/config.js
+++ b/frontend/react-front/src/config.js
@@ -1,2 +1,6 @@
 export const api_base =
   process.env.NODE_ENV === 'development' ? 'http://localhost:3000' : ''
+
+  // While on development, disable wallet authentication
+export const admin_override = 
+  process.env.NODE_ENV === 'development' ? true : false


### PR DESCRIPTION
## Monthly summed result

<img width="1254" alt="Screen Shot 2021-11-10 at 08 21 56" src="https://user-images.githubusercontent.com/9779954/141104675-72fee654-d487-4fba-a642-efd00290ca4d.png">

- Display the average monthly result (calendar month)
- Show the percentage of passed checks shown - along with a tooltip showing the number of passed checks against the total checks
- Add styling for the row
- Shown a button at right side: display "Time Machine" or the current meta-snapshot date
- Button triggers `openTimeMachine()` which should be used to display a modal for the user to select between different meta-snapshots

## Database changes

<img width="311" alt="Screen Shot 2021-11-10 at 08 18 43" src="https://user-images.githubusercontent.com/9779954/141105334-d8debd76-1cd8-41c1-817c-7017861216d7.png">

- Add the metasnapshot_date column to various tables (adminsettings, bizdev, community, pointsystem, producer, products, results)
- A SQL query to populate the database with a current meta-snapshot
- Replace the indexes to allow the storage of duplicate records with metasnapshot_date included

## Table-datagrid
- Make all rows that are in a metasnapshot uneditable
- Hide the metasnapshot_date column
- Add filtering function to allow the selective display of rows in a given meta-snapshot - with rows without a meta-snapshot date (i.e., editable, latest rows) shown by default

### Snapshot scores - Individual view 
(as you can see, no editing available)

<img width="1201" alt="Screen Shot 2021-11-10 at 08 18 21" src="https://user-images.githubusercontent.com/9779954/141105887-048598c0-3f56-46df-ba9a-ed9186fd3314.png">

### Snapshot scores - Integrated view. 
Default - editable

<img width="1250" alt="Screen Shot 2021-11-10 at 08 16 26" src="https://user-images.githubusercontent.com/9779954/141106159-ba2270d6-521d-458e-9537-bfc1394479e8.png">

Time machine / metasnapshots active - uneditable

<img width="1251" alt="Screen Shot 2021-11-10 at 08 16 44" src="https://user-images.githubusercontent.com/9779954/141106245-7e735a85-bea3-43f4-8574-37fd9c2765d8.png">

### Admin page - guild settings

Switching active status on and off works as usual

<img width="535" alt="Screen Shot 2021-11-10 at 08 15 46" src="https://user-images.githubusercontent.com/9779954/141106561-0484e558-f10d-4ff6-b4f3-2024ea771313.png">

Go back in time... and the rows are uneditable, and the values reverted. However, your latest changes are still saved when you exit the meta-snapshot.

<img width="539" alt="Screen Shot 2021-11-10 at 08 16 01" src="https://user-images.githubusercontent.com/9779954/141106596-69751ac2-19a9-47cd-a468-1658780fc1a5.png">

## Time machine / metasnapshot browser

- Function, shared inside both producer detail and navbar, to trigger a modal where you can choose between metasnapshots (note: modal not built yet, only alerts)
- Function to list currently available metasnapshots to choose from (uses adminsettings as a source of data, since it's the smallest dataset)
- Function to update the metaSnapshotDate React hook in App.js, which will affect the rest of the app

## Fastify / Admin Page

<img width="644" alt="Screen Shot 2021-11-10 at 08 13 55" src="https://user-images.githubusercontent.com/9779954/141107599-50b9806d-e519-473a-bb35-b0d5fc650dc7.png">

- Function to make meta-snapshots. Runs super fast, less than a second. Takes all current important rows:
  - minimum tech score (used to reference old scoring criteria)
  - bizdevs (primarily used to freeze comments)
  - community (primarily used to freeze comments)
  - pointsystem (used to reference old scoring criteria)
  - producer (used to reference historical top21 guilds)
  - products (primarily used to freeze comments)
  - tech results (primarily used to freeze comments)
  
- Prevents duplicate meta-snapshots from being made in one day
- 
<img width="629" alt="Screen Shot 2021-11-10 at 08 13 59" src="https://user-images.githubusercontent.com/9779954/141107608-23af0973-2672-4cd1-b8e8-0c6566225b9c.png">

## Other changes
- Navbar button to switch between meta-snapshots
- Function to find the human-readable month based off a number (e.g. 4 = April)

## Missing / Bugs / Future Improvements:

- A nice dialog box for browsing meta-snapshots. The functions for listing meta-snapshot dates and selecting them are there, we just need styling and a toggle system for showing/hiding the modal. I recommend material-ui dialog box, similar to what I've done for add-new-dialog.

- Fastify function to make a meta-snapshot of all current calendar-month tech results for every producer. Basically, the same as /truncatedPaginatedResults, but with meta-snapshot dates. This will let the "Time Machine" work for the likes of the CPU graph on the producer page. Right now, only the average monthly result updates with the current metaSnapshotDate.

- Fix Fastify functions to allow adding (inserting) and editing (updating) of products, bizdevs, communities, and (?) tech results, without messing with meta-snapshot records, nor causing duplicates. Right now the only ones I know work are on the admin panel (point system and guild settings). I believe the issue is related to the `excluded.XYZ` things.

- Improve meta-snapshot fastify function to allow updating of the current day's meta-snapshot, or deletion of meta-snapshots.