### PR TITLE
add a none button for exiting timemachine mode

### DIFF
--- a/frontend/react-front/src/App.js
+++ b/frontend/react-front/src/App.js
@@ -264,6 +264,7 @@ const App = (props) => {
                       logOut={props.ual.logout}
                       metaSnapshotDate={metaSnapshotDate}
                       openTimeMachine={openTimeMachine}
+                      setMetaSnapshotDate={setMetaSnapshotDate}
                       isAdmin={
                         adminOverride ||
                         (props.ual.activeUser &&

--- a/frontend/react-front/src/components/appbar.js
+++ b/frontend/react-front/src/components/appbar.js
@@ -99,7 +99,7 @@ const useStyles = makeStyles((theme) => ({
 
 
 
-export default function ButtonAppBar({ activeUser, loginModal, logOut, isAdmin, metaSnapshotDate, openTimeMachine }) {
+export default function ButtonAppBar({ activeUser, loginModal, logOut, isAdmin, metaSnapshotDate, openTimeMachine, setMetaSnapshotDate }) {
   const classes = useStyles();
 
   return (
@@ -118,6 +118,9 @@ export default function ButtonAppBar({ activeUser, loginModal, logOut, isAdmin, 
             OIG Portal
           </Typography>
           <nav className={classes.linkContainer}>
+            {metaSnapshotDate && (<Link variant="button" color="inherit" to="#" onClick={() => setMetaSnapshotDate(null)} className={classes.waxButton}>
+              None
+            </Link>)}
             <Link variant="button" color="inherit" to="#" onClick={openTimeMachine} className={classes.waxButton}>
               {metaSnapshotDate ? metaSnapshotDate.short : "Time Machine"}
             </Link>


### PR DESCRIPTION
This PR adds a 'None' button to the navbar of the OIG portal. When clicked, the button is used to exit the current time machine mode