### PR TITLE
Filter scorespage latest results

### DIFF
--- a/frontend/fastify/pgquery.js
+++ b/frontend/fastify/pgquery.js
@@ -260,13 +260,9 @@ const getAverageMonthlyResult = (request, reply) => {
       const vYear = !!year ? parseInt(year) : 'extract(year FROM current_date)';
       qry = qry + `and extract(month FROM date_check) = ${vMonth}
       and extract(year FROM date_check) = ${vYear}`    
-    } else if(days) {
-      // console.log('******************')
-      // console.log('GOT HERE')
-      
+    } else if(days) {   
     const vDays = parseInt(days);
     qry = qry + `and date_check > current_date - interval '${vDays}' day`;
-    // console.log('QUERY IS', qry);
   }   
   
   client.query(qry, [owner], (error, results) => {

--- a/frontend/fastify/pgquery.js
+++ b/frontend/fastify/pgquery.js
@@ -87,11 +87,22 @@ const getSnapshotResults = (request, reply) => {
 
 //Get latest Snapshot results
 const getLatestSnapshotResults = (request, reply) => {
-  client.query('SELECT DISTINCT ON (owner_name) * FROM oig.results WHERE snapshot_date IS NOT  NULL ORDER BY owner_name, snapshot_date DESC', (error, results) => {
+  let query;
+  const { metasnapshot_date } = request.params   
+  if(metasnapshot_date && metasnapshot_date !== 'None'){
+    query = `SELECT DISTINCT ON (owner_name) * FROM oig.results WHERE metasnapshot_date = timestamp '${metasnapshot_date}' ORDER BY owner_name, snapshot_date DESC`
+  }else{
+    query = 'SELECT DISTINCT ON (owner_name) * FROM oig.results WHERE snapshot_date IS NOT NULL ORDER BY owner_name, snapshot_date DESC'
+  }
+  // console.log('******************')
+  // console.log('Metasnpshot date is', metasnapshot_date)  
+  // console.log('******************') 
+  // console.log('query is', query)
+  client.query(query, (error, results) => {
     if (error) {
-      throw error
+      console.log('There was an errro with this operation', error)
     }
-    reply.status(200).send(results.rows);
+    reply.status(200).send(results.rows); 
   })
 }
 
@@ -99,7 +110,7 @@ const getLatestSnapshotResults = (request, reply) => {
 const getSnapshotSettings = (request, reply) => {
   client.query('SELECT * FROM oig.snapshotsettings', (error, results) => {
     if (error) {
-      throw error
+      console.log('There was an errro with this operation', error)
     }
     reply.status(200).send(results.rows);
   })
@@ -108,7 +119,7 @@ const getSnapshotSettings = (request, reply) => {
 const getPointSystem = (request, reply) => {
   client.query('SELECT * FROM oig.pointsystem', (error, results) => {
     if (error) {
-      throw error
+      console.log('There was an errro with this operation', error)
     }
     reply.status(200).send(results.rows);
   })
@@ -143,13 +154,8 @@ const getAdminSettings = (request, reply) => {
 const updateAdminSettings = (request, reply) => {
   const { minimum_tech_score } = request.body
 
-  // const toUpdate = (minimum_tech_score ? "minimum_tech_score=" + minimum_tech_score : "");
   const toUpdate = (minimum_tech_score ? `minimum_tech_score=${minimum_tech_score} WHERE metasnapshot_date = timestamp '1980-01-01'` : "");
   const qry = `UPDATE oig.adminsettings SET ${toUpdate}`;
-  console.log('*****************************')
-  console.log('Query is', qry);
-  console.log('*****************************')
-
 
   if (toUpdate === "") {
     reply.status(400).send(`No updates sent`);
@@ -256,7 +262,7 @@ const getAverageMonthlyResult = (request, reply) => {
     } else if(days) {
     const vDays = parseInt(days);
     qry = qry + `and date_check > current_date - interval '${vDays}' day`
-  }  
+  }   
   
   client.query(qry, [owner], (error, results) => {
     if (error) {

--- a/frontend/fastify/pgquery.js
+++ b/frontend/fastify/pgquery.js
@@ -94,10 +94,10 @@ const getLatestSnapshotResults = (request, reply) => {
   }else{
     query = 'SELECT DISTINCT ON (owner_name) * FROM oig.results WHERE snapshot_date IS NOT NULL ORDER BY owner_name, snapshot_date DESC'
   }
-  console.log('******************')
-  console.log('Metasnpshot date is', metasnapshot_date)  
-  console.log('******************')  
-  console.log('query is', query)
+  // console.log('******************')
+  // console.log('Metasnpshot date is', metasnapshot_date)  
+  // console.log('******************')  
+  // console.log('query is', query)
   client.query(query, (error, results) => {
     if (error) {
       console.log('There was an errro with this operation', error)
@@ -255,14 +255,18 @@ const getAverageMonthlyResult = (request, reply) => {
     where owner_name = $1
     `   
     
-    if(month || year){
+    if(!!month && year !== 'None'){
       const vMonth = !!month ? parseInt(month) : 'extract(month FROM current_date)';
       const vYear = !!year ? parseInt(year) : 'extract(year FROM current_date)';
       qry = qry + `and extract(month FROM date_check) = ${vMonth}
       and extract(year FROM date_check) = ${vYear}`    
     } else if(days) {
+      // console.log('******************')
+      // console.log('GOT HERE')
+      
     const vDays = parseInt(days);
-    qry = qry + `and date_check > current_date - interval '${vDays}' day`
+    qry = qry + `and date_check > current_date - interval '${vDays}' day`;
+    // console.log('QUERY IS', qry);
   }   
   
   client.query(qry, [owner], (error, results) => {

--- a/frontend/fastify/pgquery.js
+++ b/frontend/fastify/pgquery.js
@@ -94,10 +94,10 @@ const getLatestSnapshotResults = (request, reply) => {
   }else{
     query = 'SELECT DISTINCT ON (owner_name) * FROM oig.results WHERE snapshot_date IS NOT NULL ORDER BY owner_name, snapshot_date DESC'
   }
-  // console.log('******************')
-  // console.log('Metasnpshot date is', metasnapshot_date)  
-  // console.log('******************') 
-  // console.log('query is', query)
+  console.log('******************')
+  console.log('Metasnpshot date is', metasnapshot_date)  
+  console.log('******************')  
+  console.log('query is', query)
   client.query(query, (error, results) => {
     if (error) {
       console.log('There was an errro with this operation', error)
@@ -105,6 +105,7 @@ const getLatestSnapshotResults = (request, reply) => {
     reply.status(200).send(results.rows); 
   })
 }
+
 
 // Get snapshot settings (just date for now)
 const getSnapshotSettings = (request, reply) => {

--- a/frontend/fastify/server.js
+++ b/frontend/fastify/server.js
@@ -41,7 +41,7 @@ fastify.get('/api/results/:owner', db.getResultsbyOwner)
 fastify.get('/api/paginatedresults/:owner', db.getPaginatedResultsByOwner)
 // Monthly average results
 fastify.get('/api/monthlyaverageresults/:owner', db.getAverageMonthlyResult)
-fastify.get('/api/snapshotlatestresults', db.getLatestSnapshotResults)
+fastify.get('/api/snapshotlatestresults/:metasnapshot_date', db.getLatestSnapshotResults)
 // Admin panel related items: snapshot settings (including snapshot date), and point system
 fastify.get('/api/snapshotsettings', db.getSnapshotSettings)
 fastify.get('/api/pointsystem', db.getPointSystem)

--- a/frontend/react-front/src/App.js
+++ b/frontend/react-front/src/App.js
@@ -173,17 +173,16 @@ const App = (props) => {
         .map((row) => row.metasnapshot_date.substring(0, 10));        
       // availableMetaSnapshots[0] = 'None';
       setAvailableMetaSnapshots(availableMetaSnapshots);
-      console.log("Set available meta-snapshots");
-      const minScore =
-        data && data[0] && data[0].minimum_tech_score
-          ? data[0].minimum_tech_score
-          : 999;
-      // const minScoreArray = data.filter(row => row.metasnapshot_date === defaultMetaSnapshotDate)
-      // const minScoreRec = minScoreArray && minScoreArray[0] && minScoreArray[0].minimum_tech_score
-      // ? minScoreArray[0].minimum_tech_score
-      // : 999;
-      // console.log('TTTT>>>>>>>', minScoreRec);
-      setMinimumTechScore(minScore);
+      // console.log("Set available meta-snapshots");
+      // const minScore =
+      //   data && data[0] && data[0].minimum_tech_score
+      //     ? data[0].minimum_tech_score
+      //     : 999;
+      const minScoreArray = data.filter(row => row.metasnapshot_date === defaultMetaSnapshotDate)
+      const minScoreRec = minScoreArray && minScoreArray[0] && minScoreArray[0].minimum_tech_score
+      ? minScoreArray[0].minimum_tech_score
+      : 999;
+      setMinimumTechScore(minScoreRec);
     });
   }, []);
 

--- a/frontend/react-front/src/App.js
+++ b/frontend/react-front/src/App.js
@@ -151,13 +151,9 @@ const App = (props) => {
     axios.get(api_base + "/api/community").then((response) => {
       // setRawCommunity(response.data)
       setCommunity(response.data);
-    });
+    });    
     
-    axios.get(api_base + "/api/snapshotlatestresults").then((response) => {
-      // setRawSnapshotLatestResults(response.data)
-      setSnapshotLatestResults(response.data);
-    });
-    axios.get(api_base + "/api/snapshotsettings").then((response) => {
+    axios.get(api_base + "/api/snapshotsettings/").then((response) => {
       setSnapshotSettings(response.data);
     });
     axios.get(api_base + "/api/pointsystem").then((response) => {
@@ -193,12 +189,12 @@ const App = (props) => {
 
   useEffect(() => {
     axios.get(api_base + `/api/latestresults/${metaSnapshotDate ? metaSnapshotDate : defaultMetaSnapshotDate}`).then((response) => {
-      // setRawLatestResults(response.data)
       setLatestResults(response.data);
     });
-  }, [metaSnapshotDate])
-
-
+    axios.get(api_base + `/api/snapshotlatestresults/${metaSnapshotDate ? metaSnapshotDate : ''}`).then((response) => {
+      setSnapshotLatestResults(response.data);
+    });
+  }, [metaSnapshotDate]) 
 
   const BPwithownername = () => {
     let params = useParams();

--- a/frontend/react-front/src/components/integrated-snapshot-scores.js
+++ b/frontend/react-front/src/components/integrated-snapshot-scores.js
@@ -12,7 +12,7 @@ function getGuildLogoURL(guild, producers, producerLogos, producerDomainMap) {
   return getCachedImage(logosvg_url, producerLogos, producerDomainMap)
 }
 
-const App = ({ results, producers, products, bizdevs, community, isAdmin, pointSystem, producerLogos, producerDomainMap, activeGuilds }) => {
+const IntegratedScores = ({ results, producers, products, bizdevs, community, isAdmin, pointSystem, producerLogos, producerDomainMap, activeGuilds }) => {
   function format(array) {
     // Any manipulations of initially loaded data can be done here
     if (array.length >= 1) {
@@ -58,4 +58,4 @@ const App = ({ results, producers, products, bizdevs, community, isAdmin, pointS
   );
 }
 
-export default App
+export default IntegratedScores

--- a/frontend/react-front/src/components/producer-detail.js
+++ b/frontend/react-front/src/components/producer-detail.js
@@ -382,7 +382,9 @@ const App = ({
 
       let queryString;
       if(!!metaSnapshotDate){
-        queryString = `/api/monthlyaverageresults/${producer.owner_name}?month=${metaSnapshotDate.month}&year=${metaSnapshotDate.year}`; 
+        const year = metaSnapshotDate.substring(0, 4);
+        const month = metaSnapshotDate.substring(5, 7);
+        queryString = `/api/monthlyaverageresults/${producer.owner_name}?month=${month}&year=${year}`; 
       }else{
         queryString = `/api/monthlyaverageresults/${producer.owner_name}?days=${numberOfAverageDays}`; 
       }

--- a/frontend/react-front/src/components/producer-detail.js
+++ b/frontend/react-front/src/components/producer-detail.js
@@ -381,7 +381,7 @@ const App = ({
 
 
       let queryString;
-      if(!!metaSnapshotDate){
+      if(!!metaSnapshotDate && metaSnapshotDate !== 'None'){
         const year = metaSnapshotDate.substring(0, 4);
         const month = metaSnapshotDate.substring(5, 7);
         queryString = `/api/monthlyaverageresults/${producer.owner_name}?month=${month}&year=${year}`; 

--- a/frontend/react-front/src/components/snapshot-results.js
+++ b/frontend/react-front/src/components/snapshot-results.js
@@ -14,7 +14,7 @@ const useStyles = makeStyles((theme) => ({
   }
 }))
 
-const App = ({ /*results, */ producers, products, bizdevs, community, snapresults, pointSystem, isAdmin, producerLogos, producerDomainMap, activeGuilds, metaSnapshotDate, formatDate }) => {
+const SnapshotResults = ({ /*results, */ producers, products, bizdevs, community, snapresults, pointSystem, isAdmin, producerLogos, producerDomainMap, activeGuilds, metaSnapshotDate, formatDate, defaultMetaSnapshotDate }) => {
   const classes = useStyles();
 
   const [viewType, setViewType] = useState('integrated')
@@ -30,9 +30,16 @@ const App = ({ /*results, */ producers, products, bizdevs, community, snapresult
 
   const filterMetaSnapshots = (rows) => {
     if (!!metaSnapshotDate) {
-      return rows.filter(row => row.metasnapshot_date && row.metasnapshot_date.substring(0, 10) === metaSnapshotDate.date)
+      return rows.filter(row => row.metasnapshot_date && row.metasnapshot_date.substring(0, 10) === metaSnapshotDate)
     }
-    return rows.filter(row => row.metasnapshot_date === null || row.metasnapshot_date === undefined)
+    return rows.filter(row => row.metasnapshot_date === defaultMetaSnapshotDate || row.metasnapshot_date === null)
+  }
+
+  const filterMetaSnapshots2 = (rows) => {
+    if (!!metaSnapshotDate) {
+      return rows.filter(row => row.metasnapshot_date && row.metasnapshot_date.substring(0, 10) === metaSnapshotDate)
+    }
+    return rows
   }
 
   const loadView = () => {
@@ -51,7 +58,7 @@ const App = ({ /*results, */ producers, products, bizdevs, community, snapresult
     }
     if (viewType === 'integrated') {
       return <IntegratedScores
-        results={filterMetaSnapshots(snapresults)}
+        results={(snapresults)}
         producers={producers}
         products={filterMetaSnapshots(products)}
         bizdevs={filterMetaSnapshots(bizdevs)}
@@ -91,4 +98,4 @@ const App = ({ /*results, */ producers, products, bizdevs, community, snapresult
   )
 
 }
-export default App
+export default SnapshotResults


### PR DESCRIPTION
THIS PR FIXES THE FOLLOWING

1. This PR fixes the bug that causes fastify server to crash when you are viewing the guild page ---> click on timemachine --->choose None.

2. This PR Implements a filter on the scores page such that: when in none, the tech results on scores page should be based on the latest results based on date for column snapshot_date AND when in metasnapshot, the tech results on scores page should be based on the metasnapshot_date column, based on the metasnapshot you are currently viewing.

here are the executed SQL queries: depending on whether you're in a timemachine state or not.

******When in NONE OR not in a TIME MACHINE*****
SELECT DISTINCT ON (owner_name) * FROM oig.results WHERE snapshot_date IS NOT NULL ORDER BY owner_name, snapshot_date DESC

******When in TIME MACHINE METASNAPSHOT DATE (e.g 2021-11-17) *****
SELECT DISTINCT ON (owner_name) * FROM oig.results WHERE metasnapshot_date = timestamp '2021-11-17' ORDER BY owner_name, snapshot_date DESC