### PR TITLE
Make products bizdev comm editable

### DIFF
--- a/frontend/fastify/pgquery.js
+++ b/frontend/fastify/pgquery.js
@@ -396,7 +396,7 @@ const snapshotResultCommentUpdate = (request, reply) => {
 // OIG admin page
 const productUpdate = (request, reply) => {
   const { owner_name, name, description, stage, analytics_url, spec_url, code_repo, score, points, date_updated, comments } = request.body
-    console.log('body', request.body)
+    // console.log('body', request.body)
 
   client.query(
     `INSERT into oig.products (owner_name, name, description, stage, analytics_url, spec_url, code_repo, score, points, date_updated, comments, metasnapshot_date) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11, timestamp '1980-01-01 00:00:00') ON CONFLICT (owner_name) DO UPDATE SET description = EXCLUDED.description, stage = EXCLUDED.stage, analytics_url = EXCLUDED.analytics_url, spec_url = EXCLUDED.spec_url, code_repo = EXCLUDED.code_repo, score = EXCLUDED.score, points = EXCLUDED.points, date_updated= EXCLUDED.date_updated, comments= EXCLUDED.comments `,

--- a/frontend/fastify/pgquery.js
+++ b/frontend/fastify/pgquery.js
@@ -396,11 +396,12 @@ const snapshotResultCommentUpdate = (request, reply) => {
 // OIG admin page
 const productUpdate = (request, reply) => {
   const { owner_name, name, description, stage, analytics_url, spec_url, code_repo, score, points, date_updated, comments } = request.body
+    console.log('body', request.body)
 
   client.query(
-    'INSERT into oig.products (owner_name, name, description, stage, analytics_url, spec_url, code_repo, score, points, date_updated, comments) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11) ON CONFLICT (owner_name,name,metasnapshot_date) DO UPDATE SET description = EXCLUDED.description, stage = EXCLUDED.stage, analytics_url = EXCLUDED.analytics_url, spec_url = EXCLUDED.spec_url, code_repo = EXCLUDED.code_repo, score = EXCLUDED.score, points = EXCLUDED.points, date_updated= EXCLUDED.date_updated, comments= EXCLUDED.comments ',
+    `INSERT into oig.products (owner_name, name, description, stage, analytics_url, spec_url, code_repo, score, points, date_updated, comments, metasnapshot_date) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11, timestamp '1980-01-01 00:00:00') ON CONFLICT (owner_name) DO UPDATE SET description = EXCLUDED.description, stage = EXCLUDED.stage, analytics_url = EXCLUDED.analytics_url, spec_url = EXCLUDED.spec_url, code_repo = EXCLUDED.code_repo, score = EXCLUDED.score, points = EXCLUDED.points, date_updated= EXCLUDED.date_updated, comments= EXCLUDED.comments `,
     [owner_name, name, description, stage, analytics_url, spec_url, code_repo, score, points, date_updated, comments],
-    (error, results) => {
+    (error, results) => { 
       if (error) {
         throw error
       }
@@ -412,9 +413,9 @@ const productUpdate = (request, reply) => {
 // OIG admin page
 const bizdevUpdate = (request, reply) => {
   const { owner_name, name, description, stage, analytics_url, spec_url, score, points, date_updated, comments } = request.body
-
+  // console.log('body', request.body)
   client.query(
-    'INSERT into oig.bizdev (owner_name, name, description, stage, analytics_url, spec_url, score, points, date_updated, comments) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) ON CONFLICT (owner_name,name,metasnapshot_date) DO UPDATE SET description = EXCLUDED.description, stage = EXCLUDED.stage, analytics_url = EXCLUDED.analytics_url, spec_url = EXCLUDED.spec_url, score = EXCLUDED.score, points = EXCLUDED.points, date_updated= EXCLUDED.date_updated, comments= EXCLUDED.comments ',
+    'INSERT into oig.bizdev (owner_name, name, description, stage, analytics_url, spec_url, score, points, date_updated, comments) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) ON CONFLICT (owner_name) DO UPDATE SET owner_name = EXCLUDED.owner_name, description = EXCLUDED.description, stage = EXCLUDED.stage, analytics_url = EXCLUDED.analytics_url, spec_url = EXCLUDED.spec_url, score = EXCLUDED.score, points = EXCLUDED.points, date_updated= EXCLUDED.date_updated, comments= EXCLUDED.comments ',
     [owner_name, name, description, stage, analytics_url, spec_url, score, points, date_updated, comments],
     (error, results) => {
       if (error) {
@@ -428,16 +429,16 @@ const bizdevUpdate = (request, reply) => {
 // OIG admin page
 const communityUpdate = (request, reply) => {
   const { owner_name, origcontentpoints, transcontentpoints, eventpoints, managementpoints, outstandingpoints, score, date_updated, comments } = request.body
-
+  
   client.query(
-    'INSERT into oig.community (owner_name, origcontentpoints, transcontentpoints, eventpoints, managementpoints, outstandingpoints, score, date_updated, comments) VALUES ($1,$2,$3,$4,$5,$6,$7,$8, $9) ON CONFLICT (owner_name,metasnapshot_date) DO UPDATE SET origcontentpoints = EXCLUDED.origcontentpoints, transcontentpoints = EXCLUDED.transcontentpoints, eventpoints = EXCLUDED.eventpoints, managementpoints = EXCLUDED.managementpoints, score = EXCLUDED.score, date_updated= EXCLUDED.date_updated, comments= EXCLUDED.comments ',
+    'INSERT into oig.community (owner_name, origcontentpoints, transcontentpoints, eventpoints, managementpoints, outstandingpoints, score, date_updated, comments) VALUES ($1,$2,$3,$4,$5,$6,$7,$8, $9) ON CONFLICT (owner_name) DO UPDATE SET origcontentpoints = EXCLUDED.origcontentpoints, transcontentpoints = EXCLUDED.transcontentpoints, eventpoints = EXCLUDED.eventpoints, managementpoints = EXCLUDED.managementpoints, score = EXCLUDED.score, date_updated= EXCLUDED.date_updated, comments= EXCLUDED.comments ',
     [owner_name, origcontentpoints, transcontentpoints, eventpoints, managementpoints, outstandingpoints, score, date_updated, comments],
     (error, results) => {
       if (error) {
         throw error
       }
       reply.status(200).send(`Producer modified: ${owner_name}`);
-    })
+    }) 
 }
 
 // Update snapshot date

--- a/frontend/react-front/src/App.js
+++ b/frontend/react-front/src/App.js
@@ -59,6 +59,8 @@ const App = (props) => {
     "ig.kaefer",
     "wjosep.oig",
     "sentnlagents",
+    "uz.j2.wam",
+    
   ];
 
   const adminOverride = admin_override; // Whether to require wallet authentication to access admin features.

--- a/frontend/react-front/src/components/integrated-snapshot-scores.js
+++ b/frontend/react-front/src/components/integrated-snapshot-scores.js
@@ -23,7 +23,7 @@ const IntegratedScores = ({ results, producers, products, bizdevs, community, is
           ...item
         }
         return reArrangeTableHeaders(itemWithGuildLogo)
-      }).filter(result => activeGuilds.indexOf(result.owner_name) !== -1)
+      })//.filter(result => activeGuilds.indexOf(result.owner_name) !== -1)
     }
     return array
   }

--- a/frontend/react-front/src/components/table-datagrid.js
+++ b/frontend/react-front/src/components/table-datagrid.js
@@ -51,7 +51,8 @@ export default function Table({ tableData, tableTitle, defaultGuild, isAdmin, po
   }
 
   const isEditable = (key, columnObj) => {
-    if (!isAdmin || columnObj['metasnapshot_date'] !== defaultMetaSnapshotDate) {
+    // if (!isAdmin || columnObj['metasnapshot_date'] !== defaultMetaSnapshotDate) {
+    if (!isAdmin) {
       return 'never'
     }
     if (!!columnObj['date_check']) {
@@ -112,7 +113,7 @@ export default function Table({ tableData, tableTitle, defaultGuild, isAdmin, po
           ],
           padding: 'dense'
         }}
-        actions={!tableState[0].metasnapshot_date && isAdmin && type !== 'unknownType' && tableTitle !== 'Point System' ? [
+        actions={!tableState[0].metasnapshot_date && isAdmin && type !== 'unknownType' && tableTitle !== 'Point System' && tableTitle !== 'Bizdevs' ? [
           { // Only show recalc points for product, biz, and comm - though we may want to add this to tech results?
             icon: 'refresh',
             tooltip: 'Recalculate Score',
@@ -125,8 +126,9 @@ export default function Table({ tableData, tableTitle, defaultGuild, isAdmin, po
             onClick: (event, currentRow) => tryUpdateTable('toggleActive', currentRow, tableTitle, tableState, setTableState)
           }
         ] : null}
-        editable={tableState[0].metasnapshot_date && isAdmin && type !== 'unknownType' ? { // Show only for admins
-          onRowUpdate: (newRow, currentRow) => tryUpdateTable('update', currentRow, tableTitle, tableState, setTableState, type, pointSystem, newRow),
+        //editable={tableState[0].metasnapshot_date &&  isAdmin && type !== 'unknownType' ? { // Show only for admins
+        editable={isAdmin && type !== 'unknownType' ? {  // Show only for admins 
+        onRowUpdate: (newRow, currentRow) => tryUpdateTable('update', currentRow, tableTitle, tableState, setTableState, type, pointSystem, newRow),
           onRowDelete: (currentRow) => tryUpdateTable('delete', currentRow, tableTitle, tableState, setTableState, type),
         } : !tableState[0].metasnapshot_date && isAdmin ? { // No delete for snapshot tech results or point system
           onRowUpdate: (newRow, currentRow) => tryUpdateTable('update', currentRow, tableTitle, tableState, setTableState, type, pointSystem, newRow)

--- a/frontend/react-front/src/components/update-db.js
+++ b/frontend/react-front/src/components/update-db.js
@@ -62,6 +62,8 @@ const updateDb = (operation, type, payload, tableTitle, pointSystem) => {
                 name,
                 description,
                 stage,
+                analytics_url,
+                spec_url,
                 points,
                 comments
             } = payload;
@@ -73,6 +75,8 @@ const updateDb = (operation, type, payload, tableTitle, pointSystem) => {
                     stage,
                     score,
                     points: +points,
+                    analytics_url,
+                    spec_url,
                     date_updated,
                     comments
                 })


### PR DESCRIPTION
This pull requst fixes the ability to update/edit Products, bizdev and community records on /snapshot on page.

one notable change made is in the pgqury.js file where the ON CONFLICT value for th UPSERT QUERY is set to be *owner_name* for productUpdate, bizdevUpdate and communityUpdate respectively.

Kindly review my approach used

